### PR TITLE
[MSHADE-303] Suppress module-info.class warning if the file if filtered

### DIFF
--- a/src/main/java/org/apache/maven/plugins/shade/DefaultShader.java
+++ b/src/main/java/org/apache/maven/plugins/shade/DefaultShader.java
@@ -172,7 +172,7 @@ public class DefaultShader
                     
                     if ( entry.isDirectory() || isFiltered( jarFilters, name ) )
                     {
-                        confinue;
+                        continue;
                     }
 
 

--- a/src/main/java/org/apache/maven/plugins/shade/DefaultShader.java
+++ b/src/main/java/org/apache/maven/plugins/shade/DefaultShader.java
@@ -169,6 +169,12 @@ public class DefaultShader
                     JarEntry entry = j.nextElement();
 
                     String name = entry.getName();
+                    
+                    if ( entry.isDirectory() || isFiltered( jarFilters, name ) )
+                    {
+                        confinue;
+                    }
+
 
                     if ( "META-INF/INDEX.LIST".equals( name ) )
                     {
@@ -185,18 +191,15 @@ public class DefaultShader
                         continue;
                     }
 
-                    if ( !entry.isDirectory() && !isFiltered( jarFilters, name ) )
+                    try
                     {
-                        try
-                        {
-                            shadeSingleJar( shadeRequest, resources, transformers, remapper, jos, duplicates, jar,
-                                            jarFile, entry, name );
-                        }
-                        catch ( Exception e )
-                        {
-                            throw new IOException( String.format( "Problem shading JAR %s entry %s: %s", jar, name, e ),
-                                                   e );
-                        }
+                        shadeSingleJar( shadeRequest, resources, transformers, remapper, jos, duplicates, jar,
+                                        jarFile, entry, name );
+                    }
+                    catch ( Exception e )
+                    {
+                        throw new IOException( String.format( "Problem shading JAR %s entry %s: %s", jar, name, e ),
+                                               e );
                     }
                 }
 


### PR DESCRIPTION
Maven always shows “Discovered module-info.class. Shading will break its strong encapsulation.” warning, even then the user has explicitly filtered those files out. The same with “META-INF/INDEX.LIST” file. 

This pull request fixes this by applying file filters BEFORE these built-in warning checkers. 