### PR TITLE
[MSHADE-259] - Shade plugin attaches the test jar incorrectly

### DIFF
--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -504,6 +504,11 @@ public class ShadeMojo
                         projectHelper.attachArtifact( project, "java-source", shadedClassifierName + "-sources",
                                                       sourcesJar );
                     }
+                    if ( shadeTestJar )
+                    {
+                        projectHelper.attachArtifact( project, "test-jar", shadedClassifierName + "-tests",
+                                                      testJar );
+                    }
                 }
                 else if ( !renamed )
                 {
@@ -519,8 +524,6 @@ public class ShadeMojo
                             File shadedSources = shadedSourcesArtifactFile();
 
                             replaceFile( shadedSources, sourcesJar );
-
-                            projectHelper.attachArtifact( project, "java-source", "sources", shadedSources );
                         }
 
                         if ( shadeTestJar )
@@ -529,8 +532,6 @@ public class ShadeMojo
                             File shadedTests = shadedTestArtifactFile();
 
                             replaceFile( shadedTests, testJar );
-
-                            projectHelper.attachArtifact( project, "jar", "tests", shadedTests );
                         }
 
                         if ( createDependencyReducedPom )


### PR DESCRIPTION
[MSHADE-259] - Shade plugin attaches the test jar incorrectly which causes it to fail deployment, as described in MSHADE-259 or [SPARK-21544](https://issues.apache.org/jira/browse/SPARK-21544)

This PR fixes three problems in version 3.2.1 of ShadeMojo::execute() when `shadeTestJar` is true:
1. The shaded test jar is attached as type "jar" instead of the correct "test-jar" type.  This confused the duplicate jars issue, because one copy of the test jar was attached as "org.apache.spark:spark-streaming_2.11:jar:tests:2.4.0-SNAPSHOT" and the other as "org.apache.spark:spark-streaming_2.11:test-jar:tests:2.4.0-SNAPSHOT".  It is documented at https://maven.apache.org/ref/3.6.0/maven-core/artifact-handlers.html that the correct artifact type for test jars is "test-jar".
1. When `shadedArtifactAttached` is false, the test jar artifact is nevertheless attached explicitly. This causes the duplicate attachment, because the test jar is already in the attachment list from its original creation. (The same error occurs with `createSourcesJar`, and is also fixed in the patch.)
1. When `shadedArtifactAttached` is true, the shaded test jar artifact is NOT attached, and it needs to be.

I would welcome advice re creating an appropriate 'it' test for `shadeTestJar`, since one does not yet exist, but submitting this PR now so review can start.

Following this checklist to help us incorporate your contribution quickly and easily:
 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHADE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHADE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHADE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.
 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] ICLA in place (2010)
