### PR TITLE
[MSHADE-148] Don't attach exclusions that are already present

### DIFF
--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -1178,9 +1178,17 @@ public class ShadeMojo
                                 Exclusion exclusion = new Exclusion();
                                 exclusion.setArtifactId( n3.getArtifact().getArtifactId() );
                                 exclusion.setGroupId( n3.getArtifact().getGroupId() );
-                                dep.addExclusion( exclusion );
-                                modified = true;
-                                break;
+                                // only add an exclusion if it's not already present.
+                                for ( Exclusion ex : dep.getExclusions() )
+                                {
+                                    if ( !ex.getArtifactId().equals( exclusion.getArtifactId() )
+                                        || !ex.getGroupId().equals( exclusion.getGroupId() ) )
+                                    {
+                                        dep.addExclusion( exclusion );
+                                        modified = true;
+                                        break;
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Although I don't fully understand the scenarios where we re-evaluate
the exclusions of a dependency, I do know that if we do, we will add
them again, leading to a false indication that the dependency list has
changed, leading to a regeneration and re-evaluation of the list,
which then continues indefinitely, as the the same exclusions are
added again and again.

To address the leaf problem, let's ensure that we never add an
exclusion that is already present. That way, even if reevaluation
occurs, it will not result in changes.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)