### PR TITLE
[MSHADE-316] Minijar Exemptions

### DIFF
--- a/src/it/MSHADE-316/dependency/pom.xml
+++ b/src/it/MSHADE-316/dependency/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.mj</groupId>
+  <artifactId>dependency</artifactId>
+  <version>1.0</version>
+</project>

--- a/src/it/MSHADE-316/dependency/src/main/java/SomeUnusedClass.java
+++ b/src/it/MSHADE-316/dependency/src/main/java/SomeUnusedClass.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class SomeUnusedClass
+{
+}

--- a/src/it/MSHADE-316/dependency/src/main/java/SomeUsedClass.java
+++ b/src/it/MSHADE-316/dependency/src/main/java/SomeUsedClass.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ServiceLoader;
+
+public class SomeUsedClass
+{
+}

--- a/src/it/MSHADE-316/dependency/src/main/java/x/y/z/AnotherExemptedClass.java
+++ b/src/it/MSHADE-316/dependency/src/main/java/x/y/z/AnotherExemptedClass.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package x.y.z;
+
+public class AnotherExemptedClass
+{
+}

--- a/src/it/MSHADE-316/dependency/src/main/java/x/y/z/SomeExemptedClass.java
+++ b/src/it/MSHADE-316/dependency/src/main/java/x/y/z/SomeExemptedClass.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package x.y.z;
+
+public class SomeExemptedClass
+{
+}

--- a/src/it/MSHADE-316/invoker.properties
+++ b/src/it/MSHADE-316/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 1.8+

--- a/src/it/MSHADE-316/pom.xml
+++ b/src/it/MSHADE-316/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.mj</groupId>
+  <artifactId>aggregate</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>MSHADE-316</name>
+  <description>
+    Prevent minimizeJar from excluding classes that explicitly exempted.
+  </description>
+
+  <modules>
+    <module>dependency</module>
+    <module>test</module>
+  </modules>
+</project>

--- a/src/it/MSHADE-316/test/pom.xml
+++ b/src/it/MSHADE-316/test/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.mj</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.shade.mj</groupId>
+      <artifactId>dependency</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>attach-shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <minimizeJar>true</minimizeJar>
+              <exemptions>
+                <exemption>**/SomeExempted*</exemption>
+                <exemption>**\AnotherExempted*</exemption>
+              </exemptions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MSHADE-316/test/src/main/java/Main.java
+++ b/src/it/MSHADE-316/test/src/main/java/Main.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ServiceLoader;
+
+public class Main
+{
+    public SomeUsedClass essentialDependency;
+}

--- a/src/it/MSHADE-316/verify.bsh
+++ b/src/it/MSHADE-316/verify.bsh
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import java.io.*;
+import java.util.jar.*;
+
+String[] wanted =
+{
+    "Main.class",
+    "SomeUsedClass.class",
+    "x/y/z/SomeExemptedClass.class",
+    "x/y/z/AnotherExemptedClass.class"
+};
+
+String[] unwanted =
+{
+    "SomeUnusedClass.class"
+};
+
+JarFile jarFile = new JarFile( new File( basedir, "test/target/test-1.0.jar" ) );
+
+for ( String path : wanted )
+{
+    if ( jarFile.getEntry( path ) == null )
+    {
+        throw new IllegalStateException( "wanted path is missing: " + path );
+    }
+}
+
+for ( String path : unwanted )
+{
+    if ( jarFile.getEntry( path ) != null )
+    {
+        throw new IllegalStateException( "unwanted path is present: " + path );
+    }
+}
+
+jarFile.close();

--- a/src/main/java/org/apache/maven/plugins/shade/filter/SimpleFilter.java
+++ b/src/main/java/org/apache/maven/plugins/shade/filter/SimpleFilter.java
@@ -104,7 +104,7 @@ public class SimpleFilter
         return matchPaths( excludes, classFile );
     }
 
-    private boolean matchPaths( Set<String> patterns, String classFile )
+    static boolean matchPaths( Set<String> patterns, String classFile )
     {
         for ( String pattern : patterns )
         {
@@ -118,12 +118,12 @@ public class SimpleFilter
         return false;
     }
 
-    private String normalizePath( String path )
+    static String normalizePath( String path )
     {
         return ( path != null ) ? path.replace( File.separatorChar == '/' ? '\\' : '/', File.separatorChar ) : null;
     }
 
-    private Set<String> normalizePatterns( Set<String> patterns )
+    static Set<String> normalizePatterns( Set<String> patterns )
     {
         Set<String> result = new HashSet<String>();
 

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -150,7 +150,7 @@ public class ShadeMojo
      * syntax <code>groupId</code> is equivalent to <code>groupId:*:*:*</code>, <code>groupId:artifactId</code> is
      * equivalent to <code>groupId:artifactId:*:*</code> and <code>groupId:artifactId:classifier</code> is equivalent to
      * <code>groupId:artifactId:*:classifier</code>. For example:
-     * 
+     *
      * <pre>
      * &lt;artifactSet&gt;
      *   &lt;includes&gt;
@@ -167,7 +167,7 @@ public class ShadeMojo
 
     /**
      * Packages to be relocated. For example:
-     * 
+     *
      * <pre>
      * &lt;relocations&gt;
      *   &lt;relocation&gt;
@@ -182,7 +182,7 @@ public class ShadeMojo
      *   &lt;/relocation&gt;
      * &lt;/relocations&gt;
      * </pre>
-     * 
+     *
      * <em>Note:</em> Support for includes exists only since version 1.4.
      */
     @SuppressWarnings( "MismatchedReadAndWriteOfArray" )
@@ -203,7 +203,7 @@ public class ShadeMojo
      * to use an include to collect a set of files from the archive then use excludes to further reduce the set. By
      * default, all files are included and no files are excluded. If multiple filters apply to an artifact, the
      * intersection of the matched files will be included in the final JAR. For example:
-     * 
+     *
      * <pre>
      * &lt;filters&gt;
      *   &lt;filter&gt;
@@ -330,6 +330,12 @@ public class ShadeMojo
      */
     @Parameter
     private boolean minimizeJar;
+
+    /**
+     * @since 3.2.2
+     */
+    @Parameter
+    private Set<String> exemptions;
 
     /**
      * The path to the output file for the shaded artifact. When this parameter is set, the created archive will neither
@@ -490,7 +496,7 @@ public class ShadeMojo
                         replaceFile( finalFile, testJar );
                         testJar = finalFile;
                     }
-                    
+
                     renamed = true;
                 }
 
@@ -722,7 +728,7 @@ public class ShadeMojo
         coordinate.setVersion( artifact.getVersion() );
         coordinate.setExtension( "jar" );
         coordinate.setClassifier( "sources" );
-        
+
         Artifact resolvedArtifact;
         try
         {
@@ -831,7 +837,7 @@ public class ShadeMojo
 
             try
             {
-                filters.add( new MinijarFilter( project, getLog(), simpleFilters ) );
+                filters.add( new MinijarFilter( project, getLog(), simpleFilters, exemptions ) );
             }
             catch ( IOException e )
             {
@@ -1007,7 +1013,7 @@ public class ShadeMojo
                 }
 
                 File f = dependencyReducedPomLocation;
-                // MSHADE-225 
+                // MSHADE-225
                 // Works for now, maybe there's a better algorithm where no for-loop is required
                 if ( loopCounter == 0 )
                 {


### PR DESCRIPTION
Implements https://issues.apache.org/jira/browse/MSHADE-316.

New configuration option <exemptions> allows to specify patterns for files to be exempted from getting discarded by minijar filter.