### PR TITLE
[MSHADE-316] - Configuration option <excludeDefaults>

### DIFF
--- a/src/it/MSHADE-316/dependency/pom.xml
+++ b/src/it/MSHADE-316/dependency/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.mj</groupId>
+  <artifactId>dependency</artifactId>
+  <version>1.0</version>
+</project>

--- a/src/it/MSHADE-316/dependency/src/main/java/SomeUnusedClass.java
+++ b/src/it/MSHADE-316/dependency/src/main/java/SomeUnusedClass.java
@@ -1,5 +1,3 @@
-package org.apache.maven.plugins.shade.mojo;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,38 +17,6 @@ package org.apache.maven.plugins.shade.mojo;
  * under the License.
  */
 
-import java.util.Set;
-
-/**
- * @author David Blevins
- */
-public class ArchiveFilter
+public class SomeUnusedClass
 {
-    private String artifact;
-
-    private Set<String> includes;
-
-    private Set<String> excludes;
-
-    private boolean excludeDefaults = true;
-
-    public String getArtifact()
-    {
-        return artifact;
-    }
-
-    public Set<String> getIncludes()
-    {
-        return includes;
-    }
-
-    public Set<String> getExcludes()
-    {
-        return excludes;
-    }
-
-    public boolean getExcludeDefaults()
-    {
-        return excludeDefaults;
-    }
 }

--- a/src/it/MSHADE-316/dependency/src/main/java/SomeUsedClass.java
+++ b/src/it/MSHADE-316/dependency/src/main/java/SomeUsedClass.java
@@ -1,5 +1,3 @@
-package org.apache.maven.plugins.shade.mojo;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,38 +17,8 @@ package org.apache.maven.plugins.shade.mojo;
  * under the License.
  */
 
-import java.util.Set;
+import java.util.ServiceLoader;
 
-/**
- * @author David Blevins
- */
-public class ArchiveFilter
+public class SomeUsedClass
 {
-    private String artifact;
-
-    private Set<String> includes;
-
-    private Set<String> excludes;
-
-    private boolean excludeDefaults = true;
-
-    public String getArtifact()
-    {
-        return artifact;
-    }
-
-    public Set<String> getIncludes()
-    {
-        return includes;
-    }
-
-    public Set<String> getExcludes()
-    {
-        return excludes;
-    }
-
-    public boolean getExcludeDefaults()
-    {
-        return excludeDefaults;
-    }
 }

--- a/src/it/MSHADE-316/dependency/src/main/java/x/y/z/AnotherExemptedClass.java
+++ b/src/it/MSHADE-316/dependency/src/main/java/x/y/z/AnotherExemptedClass.java
@@ -1,5 +1,3 @@
-package org.apache.maven.plugins.shade.mojo;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,38 +17,8 @@ package org.apache.maven.plugins.shade.mojo;
  * under the License.
  */
 
-import java.util.Set;
+package x.y.z;
 
-/**
- * @author David Blevins
- */
-public class ArchiveFilter
+public class AnotherExemptedClass
 {
-    private String artifact;
-
-    private Set<String> includes;
-
-    private Set<String> excludes;
-
-    private boolean excludeDefaults = true;
-
-    public String getArtifact()
-    {
-        return artifact;
-    }
-
-    public Set<String> getIncludes()
-    {
-        return includes;
-    }
-
-    public Set<String> getExcludes()
-    {
-        return excludes;
-    }
-
-    public boolean getExcludeDefaults()
-    {
-        return excludeDefaults;
-    }
 }

--- a/src/it/MSHADE-316/dependency/src/main/java/x/y/z/SomeExemptedClass.java
+++ b/src/it/MSHADE-316/dependency/src/main/java/x/y/z/SomeExemptedClass.java
@@ -1,5 +1,3 @@
-package org.apache.maven.plugins.shade.mojo;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,38 +17,8 @@ package org.apache.maven.plugins.shade.mojo;
  * under the License.
  */
 
-import java.util.Set;
+package x.y.z;
 
-/**
- * @author David Blevins
- */
-public class ArchiveFilter
+public class SomeExemptedClass
 {
-    private String artifact;
-
-    private Set<String> includes;
-
-    private Set<String> excludes;
-
-    private boolean excludeDefaults = true;
-
-    public String getArtifact()
-    {
-        return artifact;
-    }
-
-    public Set<String> getIncludes()
-    {
-        return includes;
-    }
-
-    public Set<String> getExcludes()
-    {
-        return excludes;
-    }
-
-    public boolean getExcludeDefaults()
-    {
-        return excludeDefaults;
-    }
 }

--- a/src/it/MSHADE-316/pom.xml
+++ b/src/it/MSHADE-316/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.mj</groupId>
+  <artifactId>aggregate</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>MSHADE-316</name>
+  <description>
+    Prevent minimizeJar from excluding classes explicitly exempted.
+  </description>
+
+  <modules>
+    <module>dependency</module>
+    <module>test</module>
+  </modules>
+</project>

--- a/src/it/MSHADE-316/test/pom.xml
+++ b/src/it/MSHADE-316/test/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.mj</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.shade.mj</groupId>
+      <artifactId>dependency</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>attach-shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <minimizeJar>true</minimizeJar>
+              <filters>
+                <filter>
+                  <artifact>org.apache.maven.its.shade.mj:dependency</artifact>
+                  <excludeDefaults>false</excludeDefaults>
+                  <includes>
+                    <include>**/SomeExempted*</include>
+                    <include>**\AnotherExempted*</include>
+                  </includes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/MSHADE-316/test/src/main/java/Main.java
+++ b/src/it/MSHADE-316/test/src/main/java/Main.java
@@ -1,5 +1,3 @@
-package org.apache.maven.plugins.shade.mojo;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,38 +17,13 @@ package org.apache.maven.plugins.shade.mojo;
  * under the License.
  */
 
-import java.util.Set;
-
-/**
- * @author David Blevins
- */
-public class ArchiveFilter
+public class Main
 {
-    private String artifact;
+    public SomeUsedClass essentialDependency;
 
-    private Set<String> includes;
-
-    private Set<String> excludes;
-
-    private boolean excludeDefaults = true;
-
-    public String getArtifact()
+    public static void main( String[] args ) throws ClassNotFoundException
     {
-        return artifact;
-    }
-
-    public Set<String> getIncludes()
-    {
-        return includes;
-    }
-
-    public Set<String> getExcludes()
-    {
-        return excludes;
-    }
-
-    public boolean getExcludeDefaults()
-    {
-        return excludeDefaults;
+        Class.forName( "x.y.z.SomeExemptedClass" );
+        Class.forName( "x.y.z.AnotherExemptedClass" );
     }
 }

--- a/src/it/MSHADE-316/verify.bsh
+++ b/src/it/MSHADE-316/verify.bsh
@@ -1,5 +1,3 @@
-package org.apache.maven.plugins.shade.mojo;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,39 +16,38 @@ package org.apache.maven.plugins.shade.mojo;
  * specific language governing permissions and limitations
  * under the License.
  */
+import java.io.*;
+import java.util.jar.*;
 
-import java.util.Set;
-
-/**
- * @author David Blevins
- */
-public class ArchiveFilter
+String[] wanted =
 {
-    private String artifact;
+    "Main.class",
+    "SomeUsedClass.class",
+    "x/y/z/SomeExemptedClass.class",
+    "x/y/z/AnotherExemptedClass.class"
+};
 
-    private Set<String> includes;
+String[] unwanted =
+{
+    "SomeUnusedClass.class"
+};
 
-    private Set<String> excludes;
+JarFile jarFile = new JarFile( new File( basedir, "test/target/test-1.0.jar" ) );
 
-    private boolean excludeDefaults = true;
-
-    public String getArtifact()
+for ( String path : wanted )
+{
+    if ( jarFile.getEntry( path ) == null )
     {
-        return artifact;
-    }
-
-    public Set<String> getIncludes()
-    {
-        return includes;
-    }
-
-    public Set<String> getExcludes()
-    {
-        return excludes;
-    }
-
-    public boolean getExcludeDefaults()
-    {
-        return excludeDefaults;
+        throw new IllegalStateException( "wanted path is missing: " + path );
     }
 }
+
+for ( String path : unwanted )
+{
+    if ( jarFile.getEntry( path ) != null )
+    {
+        throw new IllegalStateException( "unwanted path is present: " + path );
+    }
+}
+
+jarFile.close();

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -490,7 +490,7 @@ public class ShadeMojo
                         replaceFile( finalFile, testJar );
                         testJar = finalFile;
                     }
-                    
+                
                     renamed = true;
                 }
 
@@ -712,7 +712,7 @@ public class ShadeMojo
         coordinate.setVersion( artifact.getVersion() );
         coordinate.setExtension( "jar" );
         coordinate.setClassifier( "sources" );
-        
+
         Artifact resolvedArtifact;
         try
         {
@@ -809,7 +809,7 @@ public class ShadeMojo
                     continue;
                 }
 
-                simpleFilters.add( new SimpleFilter( jars, filter.getIncludes(), filter.getExcludes() ) );
+                simpleFilters.add( new SimpleFilter( jars, filter ) );
             }
         }
 

--- a/src/site/apt/examples/includes-excludes.apt.vm
+++ b/src/site/apt/examples/includes-excludes.apt.vm
@@ -66,7 +66,7 @@ Selecting Contents for Uber JAR
   Of course, <<<\<includes\>>>> can be used as well to specify a white list of artifacts. Artifacts are denoted by a
   composite idenitifer of the form <groupId>:<artifactId>[[:<type>]:<classifier>]. Since plugin version 1.3, the
   wildcard characters '*' and '?' can be used to do glob-like pattern matching.
-  
+
 
   For fine-grained control of which classes from the selected dependencies are included, artifact filters can be used:
 
@@ -154,8 +154,9 @@ Selecting Contents for Uber JAR
 
   As of version 1.6, minimizeJar will respect classes that were specifically marked for inclusion in a filter.
   Note that specifying an include filter for classes in an artifact implicitly excludes all non-specified
-  classes in that artifact.
-  
+  classes in that artifact. <<<\<excludeDefaults\>false\<\\excludeDefaults\>>>> will override this behavior so that all
+  non-specified classes still will be included though.
+
 +-----
 <project>
   ...
@@ -186,7 +187,14 @@ Selecting Contents for Uber JAR
                        <include>**</include>
                    </includes>
                 </filter>
-              </filters>            
+                <filter>
+                   <artifact>foo:bar</artifact>
+                   <excludeDefaults>false</excludeDefaults>
+                   <includes>
+                       <include>foo/Bar.class</include>
+                   </includes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>
@@ -195,4 +203,4 @@ Selecting Contents for Uber JAR
   </build>
   ...
 </project>
-+-----  
++-----

--- a/src/test/java/org/apache/maven/plugins/shade/filter/SimpleFilterTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/filter/SimpleFilterTest.java
@@ -19,9 +19,13 @@ package org.apache.maven.plugins.shade.filter;
  * under the License.
  */
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.util.Collections;
 
 import junit.framework.TestCase;
+import org.apache.maven.plugins.shade.mojo.ArchiveFilter;
 
 /**
  * @author Benjamin Bentmann
@@ -72,6 +76,21 @@ public class SimpleFilterTest
         assertFalse( filter.isFiltered( "Test.class" ) );
         assertTrue( filter.isFiltered( "org/Test.class" ) );
         assertTrue( filter.isFiltered( "org/apache/Test.class" ) );
+
+        // given defaults shall be excluded and a specific include is given when filtering then only specific file must be included
+        final ArchiveFilter archiveFilter = mock( ArchiveFilter.class );
+        when( archiveFilter.getIncludes() ).thenReturn( Collections.singleton( "specific include" ) );
+        when( archiveFilter.getExcludes() ).thenReturn( Collections.<String> emptySet() );
+        when( archiveFilter.getExcludeDefaults() ).thenReturn( true );
+        filter = new SimpleFilter( null, archiveFilter );
+        assertFalse( filter.isFiltered( "specific include" ) );
+        assertTrue( filter.isFiltered( "some other file matched by default include" ) );
+
+        // given defaults shall be included and a specific include is given when filtering then all files must be included
+        when( archiveFilter.getExcludeDefaults() ).thenReturn( false );
+        filter = new SimpleFilter( null, archiveFilter );
+        assertFalse( filter.isFiltered( "specific include" ) );
+        assertFalse( filter.isFiltered( "some other file matched by default include" ) );
     }
 
 }


### PR DESCRIPTION
This PR adds a new configuration option `<excludeDefaults>` (default: `true` for backwards compatibility).

When set to `false`, providing an `<include>` will *not* automatically exclude all other files _anymore_.

This is useful e. g. when minijar'ing a dependency which is loaded by reflection (hence: no class is referenced but just a string is given, so a *specific include* is needed): Without this option, explicitly specifying the reflection-loaded class name would lead to an exclusion of _all_ other files!

Closes [MSHADE-316](https://issues.apache.org/jira/browse/MSHADE-316).

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)