### PR TITLE
[MSHADE-318] - Include transitive dependencies

### DIFF
--- a/src/it/MSHADE-316/dependency/src/main/java/x/y/z/SomeDependencyOfExemptedClass.java
+++ b/src/it/MSHADE-316/dependency/src/main/java/x/y/z/SomeDependencyOfExemptedClass.java
@@ -16,39 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import java.io.*;
-import java.util.jar.*;
 
-String[] wanted =
+package x.y.z;
+
+public class SomeDependencyOfExemptedClass
 {
-    "Main.class",
-    "SomeUsedClass.class",
-    "x/y/z/SomeExemptedClass.class",
-    "x/y/z/AnotherExemptedClass.class",
-    "x/y/z/SomeDependencyOfExemptedClass.class"
-};
-
-String[] unwanted =
-{
-    "SomeUnusedClass.class"
-};
-
-JarFile jarFile = new JarFile( new File( basedir, "test/target/test-1.0.jar" ) );
-
-for ( String path : wanted )
-{
-    if ( jarFile.getEntry( path ) == null )
-    {
-        throw new IllegalStateException( "wanted path is missing: " + path );
-    }
 }
-
-for ( String path : unwanted )
-{
-    if ( jarFile.getEntry( path ) != null )
-    {
-        throw new IllegalStateException( "unwanted path is present: " + path );
-    }
-}
-
-jarFile.close();

--- a/src/it/MSHADE-316/dependency/src/main/java/x/y/z/SomeExemptedClass.java
+++ b/src/it/MSHADE-316/dependency/src/main/java/x/y/z/SomeExemptedClass.java
@@ -21,4 +21,5 @@ package x.y.z;
 
 public class SomeExemptedClass
 {
+    public SomeDependencyOfExemptedClass essentialDependency;
 }

--- a/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
+++ b/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
@@ -38,7 +38,6 @@ import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -171,7 +170,7 @@ public class MinijarFilter
                                     }
 
                                     log.debug( className + " was not removed because it is a service" );
-                                    removeClass( cp, clazz );
+                                    removeClass( clazz );
                                     repeatScan = true; // check whether the found classes use services in turn
                                 }
                             }
@@ -195,7 +194,7 @@ public class MinijarFilter
         while ( repeatScan );
     }
 
-    private void removeClass( final Clazzpath clazzPath, final Clazz clazz )
+    private void removeClass( final Clazz clazz )
     {
         removable.remove( clazz );
         removable.removeAll( clazz.getTransitiveDependencies() );
@@ -267,16 +266,13 @@ public class MinijarFilter
                     if ( depClazzpathUnit != null )
                     {
                         Set<Clazz> clazzes = depClazzpathUnit.getClazzes();
-                        Iterator<Clazz> j = removable.iterator();
-                        while ( j.hasNext() )
+                        for ( final Clazz clazz : new HashSet<>( removable ) )
                         {
-                            Clazz clazz = j.next();
-
                             if ( clazzes.contains( clazz ) //
                                 && simpleFilter.isSpecificallyIncluded( clazz.getName().replace( '.', '/' ) ) )
                             {
                                 log.debug( clazz.getName() + " not removed because it was specifically included" );
-                                j.remove();
+                                removeClass( clazz );
                             }
                         }
                     }


### PR DESCRIPTION
Fixes [MSHADE-318](https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-318) - Specifically included class's dependencies are missing.

Solution: Include transitive dependencies of specifically included classes.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
