### PR TITLE
[MSHADE-298] GroovyResourceTransformer fix

### DIFF
--- a/src/main/java/org/apache/maven/plugins/shade/resource/GroovyResourceTransformer.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/GroovyResourceTransformer.java
@@ -39,7 +39,7 @@ public class GroovyResourceTransformer
     implements ResourceTransformer
 {
 
-    static final String EXT_MODULE_NAME = "META-INF/services/org.codehaus.groovy.runtime.ExtensionModule";
+    static final String EXT_MODULE_NAME = "META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule";
 
     private List<String> extensionClassesList = new ArrayList<>();
 


### PR DESCRIPTION
The current implementation of GroovyResourceTransformer does not work with the latest versions of Groovy. As of Groovy 2.5.x, the ExtensionModule files are located in META-INF/groovy, not in META-INF/services.

Old path: META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
New path: META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule

See open issue https://issues.apache.org/jira/browse/MSHADE-298