### PR TITLE
[MSHADE-284] - Shaded test JARs are always empty

### DIFF
--- a/src/it/MSHADE-284_shadeTestJar/api/pom.xml
+++ b/src/it/MSHADE-284_shadeTestJar/api/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.its.shade.stj</groupId>
+        <artifactId>mshade-284-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>mshade-284-api</artifactId>
+</project>

--- a/src/it/MSHADE-284_shadeTestJar/api/src/main/java/Api.java
+++ b/src/it/MSHADE-284_shadeTestJar/api/src/main/java/Api.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Api
+{
+}

--- a/src/it/MSHADE-284_shadeTestJar/api/src/main/resources/api-resource.txt
+++ b/src/it/MSHADE-284_shadeTestJar/api/src/main/resources/api-resource.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/src/it/MSHADE-284_shadeTestJar/api/src/test/java/ApiTest.java
+++ b/src/it/MSHADE-284_shadeTestJar/api/src/test/java/ApiTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class ApiTest
+{
+    public static void main(String[] args) {
+        new Api();
+    }
+}

--- a/src/it/MSHADE-284_shadeTestJar/api/src/test/resources/api-test-resource.txt
+++ b/src/it/MSHADE-284_shadeTestJar/api/src/test/resources/api-test-resource.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/src/it/MSHADE-284_shadeTestJar/impl/pom.xml
+++ b/src/it/MSHADE-284_shadeTestJar/impl/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.its.shade.stj</groupId>
+        <artifactId>mshade-284-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>mshade-284-impl</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.its.shade.stj</groupId>
+            <artifactId>mshade-284-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.its.shade.stj</groupId>
+            <artifactId>mshade-284-api</artifactId>
+            <type>test-jar</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/MSHADE-284_shadeTestJar/impl/src/main/java/Impl.java
+++ b/src/it/MSHADE-284_shadeTestJar/impl/src/main/java/Impl.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Impl extends Api
+{
+}

--- a/src/it/MSHADE-284_shadeTestJar/impl/src/main/resources/impl-resource.txt
+++ b/src/it/MSHADE-284_shadeTestJar/impl/src/main/resources/impl-resource.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/src/it/MSHADE-284_shadeTestJar/impl/src/test/java/ImplTest.java
+++ b/src/it/MSHADE-284_shadeTestJar/impl/src/test/java/ImplTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class ImplTest extends ApiTest
+{
+    public static void main(String[] args) {
+        new Impl();
+    }
+}

--- a/src/it/MSHADE-284_shadeTestJar/impl/src/test/resources/impl-test-resource.txt
+++ b/src/it/MSHADE-284_shadeTestJar/impl/src/test/resources/impl-test-resource.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/src/it/MSHADE-284_shadeTestJar/pom.xml
+++ b/src/it/MSHADE-284_shadeTestJar/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.its.shade.stj</groupId>
+    <artifactId>mshade-284-parent</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0</version>
+    <modules>
+        <module>api</module>
+        <module>impl</module>
+        <module>uber</module>
+    </modules>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven.its.shade.stj</groupId>
+                <artifactId>mshade-284-api</artifactId>
+                <version>1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.its.shade.stj</groupId>
+                <artifactId>mshade-284-api</artifactId>
+                <version>1.0</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.its.shade.stj</groupId>
+                <artifactId>mshade-284-impl</artifactId>
+                <version>1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.its.shade.stj</groupId>
+                <artifactId>mshade-284-impl</artifactId>
+                <version>1.0</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/MSHADE-284_shadeTestJar/uber/pom.xml
+++ b/src/it/MSHADE-284_shadeTestJar/uber/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.its.shade.stj</groupId>
+        <artifactId>mshade-284-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>mshade-284-uber</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.its.shade.stj</groupId>
+            <artifactId>mshade-284-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.its.shade.stj</groupId>
+            <artifactId>mshade-284-api</artifactId>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.its.shade.stj</groupId>
+            <artifactId>mshade-284-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.its.shade.stj</groupId>
+            <artifactId>mshade-284-impl</artifactId>
+            <type>test-jar</type>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadeTestJar>true</shadeTestJar>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/MSHADE-284_shadeTestJar/verify.groovy
+++ b/src/it/MSHADE-284_shadeTestJar/verify.groovy
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def jarFile = new java.util.jar.JarFile( new File( basedir, "uber/target/mshade-284-uber-1.0.jar" ) )
+try
+{
+    assert null != jarFile.getJarEntry( "Api.class" )
+    assert null != jarFile.getJarEntry( "api-resource.txt" )
+    assert null != jarFile.getJarEntry( "Impl.class" )
+    assert null != jarFile.getJarEntry( "impl-resource.txt" )
+    assert null == jarFile.getJarEntry( "ApiTest.class" )
+    assert null == jarFile.getJarEntry( "api-test-resource.txt" )
+    assert null == jarFile.getJarEntry( "ImplTest.class" )
+    assert null == jarFile.getJarEntry( "impl-test-resource.txt" )
+}
+finally
+{
+    jarFile.close()
+}
+
+def testJarFile = new java.util.jar.JarFile( new File( basedir, "uber/target/mshade-284-uber-1.0-tests.jar" ) )
+try
+{
+    assert null == testJarFile.getJarEntry( "Api.class" )
+    assert null == testJarFile.getJarEntry( "api-resource.txt" )
+    assert null == testJarFile.getJarEntry( "Impl.class" )
+    assert null == testJarFile.getJarEntry( "impl-resource.txt" )
+    assert null != testJarFile.getJarEntry( "ApiTest.class" )
+    assert null != testJarFile.getJarEntry( "api-test-resource.txt" )
+    assert null != testJarFile.getJarEntry( "ImplTest.class" )
+    assert null != testJarFile.getJarEntry( "impl-test-resource.txt" )
+}
+finally
+{
+    testJarFile.close()
+}


### PR DESCRIPTION
This PR fixes [MSHADE-284](https://issues.apache.org/jira/browse/MSHADE-284), which causes the test JAR to be always empty. The shadeTestJar feature was broken from day one, has never ever worked, until now.
- IT added (all the new files in this PR are for the IT).
- Code fix in ShadeMojo.java.
- Test fails before fix, succeeds after.
- "mvn clean verify" succeeds.
- "mvn -Prun-its clean verify" succeeds.
 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

[After all these years, once this PR gets merged, shadeTestJar will _finally_ work like it was supposed to, and people can stop using the assembly plugin as a workaround.](https://stackoverflow.com/questions/5149130/how-can-i-configure-the-maven-shade-plugin-to-include-test-code-in-my-jar)