### PR TITLE
[MSHADE-371] Update Shade Apache[Notice/LICENSE] ResourceTransformer to use [NOTICE/LICENSE].md

### DIFF
--- a/src/main/java/org/apache/maven/plugins/shade/resource/ApacheLicenseResourceTransformer.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/ApacheLicenseResourceTransformer.java
@@ -35,11 +35,14 @@ public class ApacheLicenseResourceTransformer
     private static final String LICENSE_PATH = "META-INF/LICENSE";
 
     private static final String LICENSE_TXT_PATH = "META-INF/LICENSE.txt";
+    
+    private static final String LICENSE_MD_PATH = "META-INF/LICENSE.md";
 
     public boolean canTransformResource( String resource )
     {
         return LICENSE_PATH.equalsIgnoreCase( resource )
-            || LICENSE_TXT_PATH.regionMatches( true, 0, resource, 0, LICENSE_TXT_PATH.length() );
+            || LICENSE_TXT_PATH.regionMatches( true, 0, resource, 0, LICENSE_TXT_PATH.length()
+            || LICENSE_MD_PATH.regionMatches( true, 0, resource, 0, LICENSE_MD_PATH.length());
     }
 
     public void processResource( String resource, InputStream is, List<Relocator> relocators, long time )

--- a/src/main/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformer.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformer.java
@@ -80,10 +80,12 @@ public class ApacheNoticeResourceTransformer
     private static final String NOTICE_PATH = "META-INF/NOTICE";
 
     private static final String NOTICE_TXT_PATH = "META-INF/NOTICE.txt";
+    
+    private static final String NOTICE_MD_PATH = "META-INF/NOTICE.md";
 
     public boolean canTransformResource( String resource )
     {
-        return NOTICE_PATH.equalsIgnoreCase( resource ) || NOTICE_TXT_PATH.equalsIgnoreCase( resource );
+        return NOTICE_PATH.equalsIgnoreCase( resource ) || NOTICE_TXT_PATH.equalsIgnoreCase( resource ) || NOTICE_MD_PATH.equalsIgnoreCase( resource );
 
     }
 

--- a/src/main/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformer.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformer.java
@@ -85,7 +85,9 @@ public class ApacheNoticeResourceTransformer
 
     public boolean canTransformResource( String resource )
     {
-        return NOTICE_PATH.equalsIgnoreCase( resource ) || NOTICE_TXT_PATH.equalsIgnoreCase( resource ) || NOTICE_MD_PATH.equalsIgnoreCase( resource );
+        return NOTICE_PATH.equalsIgnoreCase( resource ) 
+            || NOTICE_TXT_PATH.equalsIgnoreCase( resource ) 
+            || NOTICE_MD_PATH.equalsIgnoreCase( resource );
 
     }
 


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHADE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHADE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHADE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

for 
* org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer
* org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer
there is no check for LISENCE.md or NOTICE.md 

small PR wanted to add that in along with the checks for LISENCE/LISENCE.txt and NOTICE/NOTICE.txt 