### PR TITLE
MSHADE-373: adds a property to skip manifest transformer application when transforming a source file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ For changes of a trivial nature to comments and documentation, it is not always
 necessary to create a new ticket in JIRA.  In this case, it is appropriate to
 start the first line of a commit with '(doc)' instead of a ticket number.
 
+Developer Tips
+--------------
+
+If you machine is big enough and you want to parallelise the IT execution to validate the build
+before a PR you can set the concurrency in MAVEN_OPTS:
+
+````
+MAVEN_OPTS=-Dinvoker.parallelThreads=2 mvn verify -Prun-its
+````
+
+You can also run a single IT test using:
+
+````
+mvn verify -Prun-its -Dinvoker.test=myitproject
+````
+
 Additional Resources
 --------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,7 @@
               <goals>
                 <goal>package</goal>
               </goals>
+              <showErrors>true</showErrors>
               <projectsDirectory>src/it/projects</projectsDirectory>
               <settingsFile>src/it/mrm/settings.xml</settingsFile>
               <extraArtifacts>

--- a/src/it/projects/MSHADE-183/verify.bsh
+++ b/src/it/projects/MSHADE-183/verify.bsh
@@ -43,7 +43,7 @@ if ( !"org.apache.maven.Shade".equals( mf.getMainAttributes().getValue( "Main-Cl
 {
     throw new IllegalStateException( "META-INF/MANIFEST.MF is incomplete" );
 }
-if ( !"null".equals( mf.getMainAttributes().getValue( "Implementation-Build" ) ) )
+if ( null != mf.getMainAttributes().getValue( "Implementation-Build" ) )
 {
-    throw new IllegalStateException( "META-INF/MANIFEST.MF Implementation-Build content is not null as expected." );
+    throw new IllegalStateException( "META-INF/MANIFEST.MF Implementation-Build content is not null as expected. (" + mf.getMainAttributes().entrySet() + ")" );
 }

--- a/src/it/projects/MSHADE-373/pom.xml
+++ b/src/it/projects/MSHADE-373/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.mt</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <name>MSHADE-373</name>
+  <description>
+    Test that reproduces the issue described in MSHADE-373.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <!-- dummy dependency to test interaction of multiple manifests -->
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-shade-plugin</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.0.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.2</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.apache.maven.Main</mainClass>
+            </manifest>
+            <manifestEntries>
+              <Test-Entry>PASSED</Test-Entry>
+              <Original-Entry>PASSED</Original-Entry>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>attach-shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <forShade>sources-jar</forShade>
+                  <manifestEntries>
+                    <Test-Entry>FAILED</Test-Entry>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.3.1</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-373/pom.xml
+++ b/src/it/projects/MSHADE-373/pom.xml
@@ -86,12 +86,20 @@ under the License.
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createSourcesJar>true</createSourcesJar>
+              <shadeTestJar>true</shadeTestJar>
               <shadedArtifactAttached>false</shadedArtifactAttached>
               <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Custom-Entry>SET</Custom-Entry> <!-- not using original manifest but using transformer directly -->
+                  </manifestEntries>
+                </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <forShade>sources-jar</forShade>
                   <manifestEntries>
                     <Test-Entry>FAILED</Test-Entry>
+                    <Archiver-Version />
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/src/it/projects/MSHADE-373/verify.bsh
+++ b/src/it/projects/MSHADE-373/verify.bsh
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import java.io.*;
+import java.util.jar.*;
+
+// NOTE: We deliberately use JarInputStream and not JarFile here!
+JarInputStream jarStream = new JarInputStream( new FileInputStream( new File( basedir, "target/test-1.0.jar" ) ) );
+Manifest mf = jarStream.getManifest();
+jarStream.close();
+
+if ( mf == null )
+{
+    throw new IllegalStateException( "META-INF/MANIFEST.MF is missing" );
+}
+
+if ( !"PASSED".equals( mf.getMainAttributes().getValue( "Test-Entry" ) ) )
+{
+    throw new IllegalStateException( "Test-Entry should not have been changed" );
+}
+
+if ( !"PASSED".equals( mf.getMainAttributes().getValue( "Original-Entry" ) ) )
+{
+    throw new IllegalStateException( "META-INF/MANIFEST.MF is incomplete" );
+}
+
+if ( "null".equals( mf.getMainAttributes().getValue( "Implementation-Build" ) ) )
+{
+    throw new IllegalStateException( "META-INF/MANIFEST.MF Implementation-Build content is null" );
+}

--- a/src/it/projects/MSHADE-373/verify.bsh
+++ b/src/it/projects/MSHADE-373/verify.bsh
@@ -20,26 +20,43 @@ import java.io.*;
 import java.util.jar.*;
 
 // NOTE: We deliberately use JarInputStream and not JarFile here!
-JarInputStream jarStream = new JarInputStream( new FileInputStream( new File( basedir, "target/test-1.0.jar" ) ) );
-Manifest mf = jarStream.getManifest();
-jarStream.close();
-
-if ( mf == null )
-{
-    throw new IllegalStateException( "META-INF/MANIFEST.MF is missing" );
+Manifest extractManifest(name) {
+    file = new File( basedir, "target/" + name );
+    if ( !file.exists() )
+    {
+        throw new IllegalStateException( "No file '" + file + "'" );
+    }
+    JarInputStream jarStream = new JarInputStream( new FileInputStream( file ) );
+    Manifest mf = jarStream.getManifest();
+    jarStream.close();
+    return mf;
 }
 
-if ( !"PASSED".equals( mf.getMainAttributes().getValue( "Test-Entry" ) ) )
-{
-    throw new IllegalStateException( "Test-Entry should not have been changed" );
+void assertsEntries( name, expectedTestEntry, expectedOriginalEntry, expectedCustomEntry, shouldHaveArchiverVersion ) {
+    attributes = extractManifest( name ).getMainAttributes();
+
+    if ( !Objects.equals( expectedTestEntry, attributes.getValue( "Test-Entry" ) ) )
+    {
+        throw new IllegalStateException( "Test-Entry should have been '" + expectedTestEntry + "' in " + name + ": " + attributes.entrySet() );
+    }
+
+    if ( !Objects.equals( expectedOriginalEntry, attributes.getValue( "Original-Entry" ) ) )
+    {
+        throw new IllegalStateException( "Original-Entry should have been '" + expectedOriginalEntry + "' in " + name + ": " + attributes.entrySet() );
+    }
+
+    if ( !Objects.equals( expectedCustomEntry, attributes.getValue( "Custom-Entry" ) ) )
+    {
+        throw new IllegalStateException( "Custom-Entry should have been '" + expectedCustomEntry + "' in " + name + ": " + attributes.entrySet() );
+    }
+
+    if ( shouldHaveArchiverVersion && attributes.getValue( "Archiver-Version" ) == null ||
+        !shouldHaveArchiverVersion && attributes.getValue( "Archiver-Version" ) != null )
+    {
+        throw new IllegalStateException( "META-INF/MANIFEST.mf Archiver-Version entry is invalid in " + name + ": " + attributes.entrySet() );
+    }
 }
 
-if ( !"PASSED".equals( mf.getMainAttributes().getValue( "Original-Entry" ) ) )
-{
-    throw new IllegalStateException( "META-INF/MANIFEST.MF is incomplete" );
-}
-
-if ( "null".equals( mf.getMainAttributes().getValue( "Implementation-Build" ) ) )
-{
-    throw new IllegalStateException( "META-INF/MANIFEST.MF Implementation-Build content is null" );
-}
+assertsEntries( "test-1.0.jar", "PASSED", "PASSED", "SET", true );
+assertsEntries( "test-1.0-sources.jar", "FAILED", null, null, false ); // specific config
+assertsEntries( "test-1.0-tests.jar", "PASSED", "PASSED", "SET", true ); // inherits from the default transformer

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -1322,11 +1322,33 @@ public class ShadeMojo
             String shade, List<ResourceTransformer> resourceTransformers )
     {
          List<ResourceTransformer> forShade = new ArrayList<ResourceTransformer>();
+         ManifestResourceTransformer lastMt = null;
          for ( ResourceTransformer transformer : resourceTransformers )
          {
-             if ( !( transformer instanceof ManifestResourceTransformer )
-                     || ( ( ManifestResourceTransformer ) transformer ) .isForShade( shade ) )
+             if ( !( transformer instanceof ManifestResourceTransformer )  )
              {
+                 forShade.add( transformer );
+             }
+             else if ( ( ( ManifestResourceTransformer ) transformer ) .isForShade( shade ) )
+             {
+                 final ManifestResourceTransformer mt = (ManifestResourceTransformer) transformer;
+                 if ( mt.isUsedForDefaultShading() && lastMt != null && !lastMt.isUsedForDefaultShading() )
+                 {
+                     continue; // skip, we already have a specific transformer
+                 }
+                 if ( !mt.isUsedForDefaultShading() && lastMt != null && lastMt.isUsedForDefaultShading() )
+                 {
+                     forShade.remove( lastMt );
+                 }
+                 else if ( !mt.isUsedForDefaultShading() && lastMt != null )
+                 {
+                     getLog().warn( "Ambiguous manifest transformer definition for '" + shade + "': "
+                             + mt + " / " + lastMt );
+                 }
+                 if ( lastMt == null || !mt.isUsedForDefaultShading() )
+                 {
+                     lastMt = mt;
+                 }
                  forShade.add( transformer );
              }
          }

--- a/src/main/java/org/apache/maven/plugins/shade/resource/ManifestResourceTransformer.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/ManifestResourceTransformer.java
@@ -62,6 +62,8 @@ public class ManifestResourceTransformer
 
     private long time = Long.MIN_VALUE;
 
+    private String shade;
+
     public void setMainClass( String mainClass )
     {
         this.mainClass = mainClass;
@@ -187,5 +189,20 @@ public class ManifestResourceTransformer
             while ( !value.equals( newValue ) );
         }
         return newValue;
+    }
+
+    /**
+     * The shades to apply this transformer to or no shades if no filter is applied.
+     *
+     * @param shade {@code null}, {@code jar}, {@code test-jar}, {@code sources-jar} or {@code test-sources-jar}.
+     */
+    public void setForShade( String shade )
+    {
+        this.shade = shade;
+    }
+
+    public boolean isForShade( String shade )
+    {
+        return this.shade == null || this.shade.isEmpty() || this.shade.equalsIgnoreCase( shade );
     }
 }

--- a/src/main/java/org/apache/maven/plugins/shade/resource/ManifestResourceTransformer.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/ManifestResourceTransformer.java
@@ -165,7 +165,14 @@ public class ManifestResourceTransformer
         {
             for ( Map.Entry<String, Object> entry : manifestEntries.entrySet() )
             {
-                attributes.put( new Attributes.Name( entry.getKey() ), entry.getValue() );
+                if ( entry.getValue() == null )
+                {
+                    attributes.remove( new Attributes.Name( entry.getKey() ) );
+                }
+                else
+                {
+                    attributes.put( new Attributes.Name( entry.getKey() ), entry.getValue() );
+                }
             }
         }
 
@@ -203,6 +210,11 @@ public class ManifestResourceTransformer
 
     public boolean isForShade( String shade )
     {
-        return this.shade == null || this.shade.isEmpty() || this.shade.equalsIgnoreCase( shade );
+        return isUsedForDefaultShading() || this.shade.equalsIgnoreCase( shade );
+    }
+
+    public boolean isUsedForDefaultShading()
+    {
+        return this.shade == null || this.shade.isEmpty();
     }
 }


### PR DESCRIPTION
Manifest transformers in the shade plugin are often used to add meta-data for OSGi use since the shade and OSGi plugins are not overly compatible. If the same transformer is applied to the source plugin's manifest, the resolution will fail due to a duplicate bundle id.

It is therefore necessary to being able to opt-out of the manifest transformer when shading a source file. An example of this problem is documented in https://github.com/raphw/byte-buddy/issues/894.

https://issues.apache.org/jira/browse/MSHADE-373