### PR TITLE
[MSHADE-252] - Make source shading respect package/class name excludes

### DIFF
--- a/src/main/java/org/apache/maven/plugins/shade/relocation/SimpleRelocator.java
+++ b/src/main/java/org/apache/maven/plugins/shade/relocation/SimpleRelocator.java
@@ -114,15 +114,13 @@ public class SimpleRelocator
         if ( patterns != null && !patterns.isEmpty() )
         {
             normalized = new LinkedHashSet<>();
-
             for ( String pattern : patterns )
             {
-
                 String classPattern = pattern.replace( '.', '/' );
-
                 normalized.add( classPattern );
-
-                if ( classPattern.endsWith( "/*" ) )
+                // Actually, class patterns should just use 'foo.bar.*' ending with a single asterisk, but some users
+                // mistake them for path patterns like 'my/path/**', so let us be a bit more lenient here.
+                if ( classPattern.endsWith( "/*" ) || classPattern.endsWith( "/**" ) )
                 {
                     String packagePattern = classPattern.substring( 0, classPattern.lastIndexOf( '/' ) );
                     normalized.add( packagePattern );

--- a/src/test/java/org/apache/maven/plugins/shade/relocation/SimpleRelocatorTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/relocation/SimpleRelocatorTest.java
@@ -188,4 +188,71 @@ public class SimpleRelocatorTest
         assertTrue( relocator.canRelocatePath( "META-INF/maven/com-foo-bar/artifactId/pom.xml" ) );
 
     }
+
+    private static final String sourceFile =
+            "package org.apache.maven.hello;\n" +
+            "\n" +
+            "import foo.bar.Bar;\n" +
+            "import zot.baz.Baz;\n" +
+            "import org.apache.maven.exclude1.Ex1;\n" +
+            "import org.apache.maven.exclude1.a.b.Ex1AB;\n" +
+            "import org.apache.maven.sub.exclude2.Ex2;\n" +
+            "import org.apache.maven.sub.exclude2.c.d.Ex2CD;\n" +
+            "import org.apache.maven.In;\n" +
+            "import org.apache.maven.e.InE;\n" +
+            "import org.apache.maven.f.g.InFG;\n" +
+            "\n" +
+            "public class MyClass {\n" +
+            "  private org.apache.maven.exclude1.x.X myX;\n" +
+            "  private org.apache.maven.h.H;\n" +
+            "\n" +
+            "  public void doSomething() {\n" +
+            "    String noRelocation = \"NoWordBoundaryXXXorg.apache.maven.In\";\n" +
+            "    String relocationPackage = \"org.apache.maven.In\";\n" +
+            "    String relocationPath = \"org/apache/maven/In\";\n" +
+            "  }\n" +
+            "}\n";
+
+    private static final String relocatedFile =
+            "package com.acme.maven.hello;\n" +
+            "\n" +
+            "import foo.bar.Bar;\n" +
+            "import zot.baz.Baz;\n" +
+            "import org.apache.maven.exclude1.Ex1;\n" +
+            "import org.apache.maven.exclude1.a.b.Ex1AB;\n" +
+            "import org.apache.maven.sub.exclude2.Ex2;\n" +
+            "import org.apache.maven.sub.exclude2.c.d.Ex2CD;\n" +
+            "import com.acme.maven.In;\n" +
+            "import com.acme.maven.e.InE;\n" +
+            "import com.acme.maven.f.g.InFG;\n" +
+            "\n" +
+            "public class MyClass {\n" +
+            "  private org.apache.maven.exclude1.x.X myX;\n" +
+            "  private com.acme.maven.h.H;\n" +
+            "\n" +
+            "  public void doSomething() {\n" +
+            "    String noRelocation = \"NoWordBoundaryXXXorg.apache.maven.In\";\n" +
+            "    String relocationPackage = \"com.acme.maven.In\";\n" +
+            "    String relocationPath = \"com/acme/maven/In\";\n" +
+            "  }\n" +
+            "}\n";
+
+    @Test
+    public void testRelocateSourceWithExcludesRaw()
+    {
+        SimpleRelocator relocator = new SimpleRelocator( "org.apache.maven", "com.acme.maven",
+                Arrays.asList( "foo.bar", "zot.baz" ),
+                Arrays.asList( "irrelevant.exclude", "org.apache.maven.exclude1", "org.apache.maven.sub.exclude2" ),
+                true );
+        assertEquals( sourceFile,  relocator.applyToSourceContent( sourceFile ) );
+    }
+
+    @Test
+    public void testRelocateSourceWithExcludes()
+    {
+        SimpleRelocator relocator = new SimpleRelocator( "org.apache.maven", "com.acme.maven",
+                Arrays.asList( "foo.bar", "zot.baz" ),
+                Arrays.asList( "irrelevant.exclude", "org.apache.maven.exclude1", "org.apache.maven.sub.exclude2" ) );
+        assertEquals( relocatedFile,  relocator.applyToSourceContent( sourceFile ) );
+    }
 }


### PR DESCRIPTION
**1. Make source shading respect package/class name excludes**

Fixes MSHADE-252.

Until now, there was a naive global search + replace for mapping `<pattern>` to `<shadedPattern>`, even if the corresponding packages are to be ignored. This works for binary JARs, but was completely broken for source JARs.

See also my related [comment in MSHADE-252](https://issues.apache.org/jira/browse/MSHADE-252?focusedCommentId=17314377&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17314377).

With this fix, on the one hand string replacement in source files works for both "dotty" strings like `my.package.name.Foo` and "slashy" ones like `/my/package/name/resource.properties`. On the other hand, source files are now being parsed `<pattern>` match by match and for each match the excludes list will be checked and replacements only performed if the corresponding matched package name is not on the excludes list. This is of course slower than just a raw `replaceAll(..)`, but it produces correct results.

---

**2. Make relocation ex-/include matching more lenient, accepting `.**` too**

Actually, class patterns are supposed to should just use `foo.bar.*` ending with a single asterisk, but some users mistake them for path patterns like `my/path/**`, so let us be a bit more lenient here.

See also my related [comment in MSHADE-252](https://issues.apache.org/jira/browse/MSHADE-252?focusedCommentId=17314393&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17314393).

---

I have just sent my **Contributor License Agreement** to the Apache secretary's e-mail address. I hope is shall be processed quickly.

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHADE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHADE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHADE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

