### PR TITLE
[MSHADE-389] Get rid of old baggage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.25</version>
+      <version>1.7.30</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -167,10 +167,6 @@
           <groupId>org.sonatype.sisu</groupId>
           <artifactId>sisu-inject-plexus</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-annotations</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
 
@@ -200,12 +196,6 @@
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-tree</artifactId>
       <version>3.0.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -233,6 +223,11 @@
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-component-annotations</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,9 @@
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.0</mavenVersion>
+    <mavenVersion>3.1.1</mavenVersion>
     <javaVersion>7</javaVersion>
+    <sisu.version>0.3.4</sisu.version>
     <currentVersion>${project.version}</currentVersion>
     <asmVersion>9.1</asmVersion>
     <project.build.outputTimestamp>2020-05-23T15:29:40Z</project.build.outputTimestamp>
@@ -96,16 +97,39 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.plexus</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.sonatype.sisu</groupId>
+          <artifactId>sisu-inject-plexus</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.plexus</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-component-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -125,12 +149,60 @@
       <version>3.3.0</version>
     </dependency>
 
+    <!-- DI -->
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+      <version>${sisu.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Used by: TransformerTesterRule only -->
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <version>${sisu.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Make sure this goes to test only -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-component-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.sisu</groupId>
+      <artifactId>sisu-guice</artifactId>
+      <version>3.2.6</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-artifact-transfer</artifactId>
       <version>0.13.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.sonatype.sisu</groupId>
+          <artifactId>sisu-inject-plexus</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-component-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
     <!-- Others -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+    </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
@@ -151,6 +223,12 @@
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-tree</artifactId>
       <version>3.0.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-component-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -163,37 +241,35 @@
       <version>2.6.0</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-component-annotations</artifactId>
-      <scope>provided</scope>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.8.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>4.2</version>
     </dependency>
 
+    <!-- Test -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.25</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-legacy</artifactId>
       <version>2.7.0</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>30.0-android</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
-    </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
@@ -244,21 +320,33 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>sisu-maven-plugin</artifactId>
+          <version>${sisu.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>main-index</goal>
+                <goal>test-index</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>generate-metadata</goal>
-              <goal>generate-test-metadata</goal>
-            </goals>
-          </execution>
-        </executions>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -298,13 +298,6 @@
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <forceJavacCompilerUse>true</forceJavacCompilerUse>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.eclipse.sisu</groupId>
           <artifactId>sisu-maven-plugin</artifactId>
           <version>${sisu.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -226,11 +226,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-component-annotations</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-guice</artifactId>
       <scope>test</scope>
@@ -239,6 +234,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
@@ -154,6 +155,7 @@
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.sisu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,26 @@
     </contributor>
   </contributors>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>org.eclipse.sisu.inject</artifactId>
+        <version>${sisu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>org.eclipse.sisu.plexus</artifactId>
+        <version>${sisu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-guice</artifactId>
+        <version>3.2.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Maven -->
     <dependency>
@@ -98,12 +118,6 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>${mavenVersion}</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.sisu</groupId>
-          <artifactId>org.eclipse.sisu.plexus</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -116,20 +130,6 @@
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-inject-plexus</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.sisu</groupId>
-          <artifactId>org.eclipse.sisu.plexus</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -155,31 +155,6 @@
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.sisu</groupId>
-      <artifactId>org.eclipse.sisu.inject</artifactId>
-      <version>${sisu.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <!-- Used by: TransformerTesterRule only -->
-    <dependency>
-      <groupId>org.eclipse.sisu</groupId>
-      <artifactId>org.eclipse.sisu.plexus</artifactId>
-      <version>${sisu.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- Make sure this goes to test only -->
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-component-annotations</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-guice</artifactId>
-      <version>3.2.6</version>
       <scope>provided</scope>
     </dependency>
 
@@ -254,16 +229,21 @@
     </dependency>
 
     <!-- Test -->
+    <!-- Used by: TransformerTesterRule only -->
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.sisu</groupId>
+      <artifactId>sisu-guice</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>1.7.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/apache/maven/plugins/shade/Shader.java
+++ b/src/main/java/org/apache/maven/plugins/shade/Shader.java
@@ -28,8 +28,6 @@ import org.apache.maven.plugin.MojoExecutionException;
  */
 public interface Shader
 {
-    String ROLE = Shader.class.getName();
-
     /**
      * Perform a shading operation.
      *

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -646,7 +646,7 @@ public class ShadeMojo
             if ( shader == null )
             {
                 throw new MojoExecutionException(
-                    "unable to lookup own Shader implementation with hint:'" + shaderHint + "'"
+                    "unable to lookup own Shader implementation with hint: '" + shaderHint + "'"
                 );
             }
         }

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -55,12 +55,6 @@ import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
-import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
-import org.codehaus.plexus.context.Context;
-import org.codehaus.plexus.context.ContextException;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.WriterFactory;
 
@@ -81,6 +75,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 /**
  * Mojo that performs shading delegating to the Shader component.
  *
@@ -94,7 +90,6 @@ import java.util.Set;
 // CHECKSTYLE_ON: LineLength
 public class ShadeMojo
     extends AbstractMojo
-    implements Contextualizable
 {
     /**
      * The current Maven session.
@@ -375,15 +370,10 @@ public class ShadeMojo
     private boolean shadeTestJar;
 
     /**
-     * @since 1.6
+     * All the present Shaders.
      */
-    private PlexusContainer plexusContainer;
-
-    public void contextualize( Context context )
-        throws ContextException
-    {
-        plexusContainer = (PlexusContainer) context.get( PlexusConstants.PLEXUS_KEY );
-    }
+    @Inject
+    private Map<String, Shader> shaders;
 
     /**
      * @throws MojoExecutionException in case of an error.
@@ -651,14 +641,13 @@ public class ShadeMojo
     {
         if ( shaderHint != null )
         {
-            try
+            shader = shaders.get( shaderHint );
+
+            if ( shader == null )
             {
-                shader = (Shader) plexusContainer.lookup( Shader.ROLE, shaderHint );
-            }
-            catch ( ComponentLookupException e )
-            {
-                throw new MojoExecutionException( "unable to lookup own Shader implementation with hint:'" + shaderHint
-                    + "'", e );
+                throw new MojoExecutionException(
+                    "unable to lookup own Shader implementation with hint:'" + shaderHint + "'"
+                );
             }
         }
     }

--- a/src/test/java/org/apache/maven/plugins/shade/DefaultShaderTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/DefaultShaderTest.java
@@ -46,9 +46,6 @@ import org.apache.maven.plugins.shade.relocation.SimpleRelocator;
 import org.apache.maven.plugins.shade.resource.AppendingTransformer;
 import org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer;
 import org.apache.maven.plugins.shade.resource.ResourceTransformer;
-import org.codehaus.plexus.logging.AbstractLogger;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.IOUtil;
 import org.junit.Assert;
 import org.junit.Test;
@@ -56,6 +53,7 @@ import org.junit.rules.TemporaryFolder;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
+import org.slf4j.helpers.MarkerIgnoringBase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -71,9 +69,8 @@ public class DefaultShaderTest
 
     @Test
     public void testOverlappingResourcesAreLogged() throws IOException, MojoExecutionException {
-        final DefaultShader shader = new DefaultShader();
         final MockLogger logs = new MockLogger();
-        shader.enableLogging(logs);
+        final DefaultShader shader = new DefaultShader( logs );
 
         // we will shade two jars and expect to see META-INF/MANIFEST.MF overlaps, this will always be true
         // but this can lead to a broken deployment if intended for OSGi or so, so even this should be logged
@@ -133,14 +130,12 @@ public class DefaultShaderTest
         shadeRequest.setFilters( Collections.<Filter>emptyList() );
         shadeRequest.setUberJar( new File( "target/foo-custom_testOverlappingResourcesAreLogged.jar" ) );
 
-        DefaultShader shaderWithTransformer = new DefaultShader();
         final MockLogger logWithTransformer = new MockLogger();
-        shaderWithTransformer.enableLogging( logWithTransformer );
+        DefaultShader shaderWithTransformer = new DefaultShader( logWithTransformer );
         shaderWithTransformer.shade( shadeRequest );
 
-        DefaultShader shaderWithoutTransformer = new DefaultShader();
         MockLogger logWithoutTransformer = new MockLogger();
-        shaderWithoutTransformer.enableLogging( logWithoutTransformer );
+        DefaultShader shaderWithoutTransformer = new DefaultShader( logWithoutTransformer );
         shadeRequest.setResourceTransformers( Collections.<ResourceTransformer>emptyList() );
         shaderWithoutTransformer.shade( shadeRequest );
 
@@ -364,55 +359,162 @@ public class DefaultShaderTest
     {
         DefaultShader s = new DefaultShader();
 
-        s.enableLogging( new ConsoleLogger( Logger.LEVEL_INFO, "TEST" ) );
-
         return s;
     }
 
-    private static class MockLogger extends AbstractLogger
+    private static class MockLogger extends MarkerIgnoringBase
     {
         private final List<String> debugMessages = new ArrayList<>();
         private final List<String> warnMessages = new ArrayList<>();
 
-        private MockLogger()
-        {
-            super( Logger.LEVEL_INFO, "test" );
+        @Override
+        public void debug(String s, Throwable throwable) {
+            throw new IllegalStateException("should not be called");
         }
 
         @Override
-        public void debug( String s, Throwable throwable )
-        {
-            debugMessages.add( s.replace( '\\', '/' ).trim() );
+        public void warn(String s, Throwable throwable) {
+            throw new IllegalStateException("should not be called");
         }
 
         @Override
-        public void info( String s, Throwable throwable )
-        {
-            // no-op
+        public boolean isTraceEnabled() {
+            return false;
         }
 
         @Override
-        public void warn( String s, Throwable throwable )
-        {
-            warnMessages.add( s.replace( '\\', '/' ).trim() );
+        public void trace(final String s) {
+            throw new IllegalStateException("should not be called");
         }
 
         @Override
-        public void error( String s, Throwable throwable )
-        {
-            // no-op
+        public void trace(final String s, final Object o) {
+            throw new IllegalStateException("should not be called");
         }
 
         @Override
-        public void fatalError( String s, Throwable throwable )
-        {
-            // no-op
+        public void trace(final String s, final Object o, final Object o1) {
+            throw new IllegalStateException("should not be called");
         }
 
         @Override
-        public Logger getChildLogger( String s )
-        {
-            return this;
+        public void trace(final String s, final Object... objects) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void trace(final String s, final Throwable throwable) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return true;
+        }
+
+        @Override
+        public void debug(final String s) {
+            debugMessages.add(s.replace('\\', '/').trim());
+        }
+
+        @Override
+        public void debug(final String s, final Object o) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void debug(final String s, final Object o, final Object o1) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void debug(final String s, final Object... objects) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return false;
+        }
+
+        @Override
+        public void info(final String s) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void info(final String s, final Object o) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void info(final String s, final Object o, final Object o1) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void info(final String s, final Object... objects) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void info(final String s, final Throwable throwable) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return true;
+        }
+
+        @Override
+        public void warn(final String s) {
+            warnMessages.add(s.replace('\\', '/').trim());
+        }
+
+        @Override
+        public void warn(final String s, final Object o) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void warn(final String s, final Object... objects) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void warn(final String s, final Object o, final Object o1) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return false;
+        }
+
+        @Override
+        public void error(final String s) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void error(final String s, final Object o) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void error(final String s, final Object o, final Object o1) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void error(final String s, final Object... objects) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public void error(final String s, final Throwable throwable) {
+            throw new IllegalStateException("should not be called");
         }
     }
 }

--- a/src/test/java/org/apache/maven/plugins/shade/DefaultShaderTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/DefaultShaderTest.java
@@ -47,6 +47,7 @@ import org.apache.maven.plugins.shade.resource.AppendingTransformer;
 import org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer;
 import org.apache.maven.plugins.shade.resource.ResourceTransformer;
 import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.Os;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -97,8 +98,14 @@ public class DefaultShaderTest
             hasItem(containsString("plexus-utils-1.4.1.jar, test-project-1.0-SNAPSHOT.jar define 1 overlapping resource:")));
         assertThat(warnMessages.getAllValues(),
             hasItem(containsString("- META-INF/MANIFEST.MF")));
-        assertThat(debugMessages.getAllValues(),
-            hasItem(containsString("We have a duplicate META-INF/MANIFEST.MF in src/test/jars/plexus-utils-1.4.1.jar")));
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            assertThat(debugMessages.getAllValues(),
+                hasItem(containsString("We have a duplicate META-INF/MANIFEST.MF in src\\test\\jars\\plexus-utils-1.4.1.jar")));
+        }
+        else {
+            assertThat(debugMessages.getAllValues(),
+                hasItem(containsString("We have a duplicate META-INF/MANIFEST.MF in src/test/jars/plexus-utils-1.4.1.jar")));
+        }
     }
 
     @Test

--- a/src/test/java/org/apache/maven/plugins/shade/MockShader.java
+++ b/src/test/java/org/apache/maven/plugins/shade/MockShader.java
@@ -19,14 +19,17 @@ package org.apache.maven.plugins.shade;
  */
 
 import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.plexus.component.annotations.Component;
 
 import java.io.IOException;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 /**
  * @author Olivier Lamy
  */
-@Component( role = Shader.class, hint = "mock" )
+@Singleton
+@Named( "mock" )
 public class MockShader
     implements Shader
 {

--- a/src/test/java/org/apache/maven/plugins/shade/mojo/ShadeMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/mojo/ShadeMojoTest.java
@@ -53,6 +53,8 @@ import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResult;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusTestCase;
 
 /**
@@ -62,6 +64,11 @@ import org.codehaus.plexus.PlexusTestCase;
 public class ShadeMojoTest
     extends PlexusTestCase
 {
+    @Override
+    protected void customizeContainerConfiguration(final ContainerConfiguration configuration) {
+        configuration.setClassPathScanning(PlexusConstants.SCANNING_INDEX);
+    }
+
     public void testManifestTransformerSelection() throws Exception
     {
         final ShadeMojo mojo = new ShadeMojo();
@@ -126,7 +133,7 @@ public class ShadeMojoTest
     {
         File jarFile = new File( getBasedir(), "target/unit/foo-bar.jar" );
 
-        Shader s = (Shader) lookup( Shader.ROLE, "default" );
+        Shader s = lookup( Shader.class );
 
         Set<File> set = new LinkedHashSet<>();
         set.add( new File( getBasedir(), "src/test/jars/test-artifact-1.0-SNAPSHOT.jar" ) );
@@ -224,7 +231,7 @@ public class ShadeMojoTest
 
         // create and configure MavenProject
         MavenProject project = new MavenProject();
-        ArtifactHandler artifactHandler = (ArtifactHandler) lookup( ArtifactHandler.ROLE );
+        ArtifactHandler artifactHandler = lookup( ArtifactHandler.class );
         Artifact artifact = new DefaultArtifact( "org.apache.myfaces.core", "myfaces-impl",
                                                  VersionRange.createFromVersion( "2.0.1-SNAPSHOT" ), "compile", "jar",
                                                  null, artifactHandler );
@@ -266,7 +273,7 @@ public class ShadeMojoTest
     public void shaderWithPattern( String shadedPattern, File jar )
         throws Exception
     {
-        Shader s = (Shader) lookup( Shader.ROLE );
+        Shader s = lookup( Shader.class );
 
         Set<File> set = new LinkedHashSet<>();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MSHADE-389

Changes:
* get rid of Plexus Container et al (container, annotations, AbstractLogEnabled, etc)
* get rid of use of Guava (only Multimap was used from it, use commons-collections4 instead)
* up to Maven 3.1.x
* Note: UTs are still using PlexusTestCase as Maven 3.1.x has no SISU index

