### PR TITLE
Fix for Java16+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <groupId>org.sonatype.sisu</groupId>
         <artifactId>sisu-guice</artifactId>
         <version>3.2.6</version>
+        <classifier>no_aop</classifier>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -228,6 +229,7 @@
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-guice</artifactId>
+      <classifier>no_aop</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -252,6 +254,12 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.28.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.30</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
The commit fa5e40dc59355163d89cd904fcf4c4724ba3d3d6
made build fail on Java16 due illegal reflective access.

The commit is wrong that is uses "aop" guice, that is
the culprit of illegal reflective access (on Java11
generates a warning on system out, but Java16
prevents it).

Solution: use the "no_aop" guice instead. Also,
there was a SLF4J warning about non existence of
backend in tests, fixed by adding simple backend
with test scope.

Hudson failure on master:
https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-shade-plugin/job/master/40/

This PR built on Hudson:
https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-shade-plugin/job/fix-java16/1/
