### PR TITLE
[MSHADE-419] createDependencyReducedPom should not replace original pom when shadedArtifactAttached

### DIFF
--- a/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/api/pom.xml
+++ b/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/api/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.its.shade.cdrp-mm</groupId>
+        <artifactId>mshade-419-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>mshade-419-api</artifactId>
+    <version>1.0</version>
+</project>

--- a/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/api/src/main/java/Api.java
+++ b/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/api/src/main/java/Api.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Api
+{
+}

--- a/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/impl-user/pom.xml
+++ b/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/impl-user/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.its.shade.cdrp-mm</groupId>
+        <artifactId>mshade-419-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>mshade-419-simple-user</artifactId>
+    <version>1.0</version>
+    <dependencies>
+        <dependency>
+            <!-- MSHADE-419:
+            The mshade-419-impl project attaches a shaded jar, which we do not use here.
+            Thus, we would expect transitive dependencies to still get pulled in.
+            However, the compilation of this project fails with:
+
+            SimpleUser.java:[23,5] cannot find symbol
+              symbol:   class Api
+
+            Note that both the normal and the shaded jar of mshade-419-impl are created with
+            the correct pom.
+            The missing transitive dependencies only manifest themselves in a multimodule build.
+            -->
+            <groupId>org.apache.maven.its.shade.cdrp-mm</groupId>
+            <artifactId>mshade-419-impl</artifactId>
+            <version>1.0</version>
+            <type>jar</type>
+            <!-- uncommenting the following avoids the MSHADE-419 problem -->
+            <!-- <classifier>shaded</classifier> -->
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/impl-user/src/main/java/SimpleUser.java
+++ b/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/impl-user/src/main/java/SimpleUser.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class SimpleUser
+{
+    Impl impl = new Impl();
+    Api api = new Impl();
+}

--- a/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/impl/pom.xml
+++ b/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/impl/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.its.shade.cdrp-mm</groupId>
+        <artifactId>mshade-419-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>mshade-419-impl</artifactId>
+    <version>1.0</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.its.shade.cdrp-mm</groupId>
+            <artifactId>mshade-419-api</artifactId>
+            <version>1.0</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <!-- uncommenting the following avoids the MSHADE-419 problem -->
+                            <!-- <createDependencyReducedPom>false</createDependencyReducedPom> -->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/impl/src/main/java/Impl.java
+++ b/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/impl/src/main/java/Impl.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Impl extends Api
+{
+}

--- a/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/pom.xml
+++ b/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.its.shade.cdrp-mm</groupId>
+    <artifactId>mshade-419-parent</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0</version>
+    <modules>
+        <module>api</module>
+        <module>impl</module>
+        <module>impl-user</module>
+    </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/verify.groovy
+++ b/src/it/projects/MSHADE-419_createDependencyReducedPom_multimodule/verify.groovy
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.jar.*
+import org.codehaus.plexus.util.*
+
+// note that the following checks were passing even before any fix for MSHADE-419,
+// since the generated poms and jars are generated correctly.
+// only compilation of the impl-user module is failing because it uses the normal jar but
+// without its transitive dependencies
+
+String jarPrefix = "impl/target/mshade-419-impl-1.0"
+String jarPomPath = "META-INF/maven/org.apache.maven.its.shade.cdrp-mm/mshade-419-impl/pom.xml"
+String apiDependencyString = "<artifactId>mshade-419-api</artifactId>"
+
+String mainPomFileContent = FileUtils.fileRead( new File( basedir, "impl/pom.xml" ), "UTF-8" )
+if ( !mainPomFileContent.contains( apiDependencyString ) )
+{
+    throw new IllegalStateException( "The pom.xml should still contain the api dependency:\n" + mainPomFileContent )
+}
+
+String reducedPomFileContent = FileUtils.fileRead( new File( basedir, "impl/dependency-reduced-pom.xml" ), "UTF-8" )
+if ( reducedPomFileContent.contains( apiDependencyString ) )
+{
+    throw new IllegalStateException( "The dependency-reduced-pom.xml should not contain the api dependency:\n" + reducedPomFileContent )
+}
+
+JarFile jarFile = null
+try
+{
+    jarFile = new JarFile ( new File( basedir, jarPrefix + ".jar" ) )
+    JarEntry jarEntry = jarFile.getEntry(jarPomPath  )
+    String pomFile = IOUtil.toString( jarFile.getInputStream( jarEntry ), "UTF-8" )
+    if ( !pomFile.contains( apiDependencyString ) )
+    {
+        throw new IllegalStateException( "The pom.xml in the normal jar should still contain the api dependency:\n" + pomFile )
+    }
+}
+finally
+{
+    if ( jarFile != null )
+    {
+        jarFile.close()
+    }
+}


### PR DESCRIPTION
### Description:

The problem was introduced by [MSHADE-321](https://github.com/apache/maven-shade-plugin/commit/6ea8543b8b380bd4ebc0e876970957426bb46808) in 3.3.0 because before,
the `createDependencyReducedPom` method was only ever called when
`shadedArtifactAttached` is false.

The `createDependencyReducedPom` method not only writes the dependency
reduced pom file but also modifies the current project to use it as
replacement for its original pom.
This has an effect on all maven build logic being executed afterwards.

Thus, in multi module builds, when a module attaches a shaded jar, its
non-shaded artifact no longer contains transitive dependencies when used
from other modules, even though the pom in its jar still declares them.

### Checklist

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHADE-419) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHADE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHADE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).