### PR TITLE
[MSHADE-366] "Access denied" during 'minimizeJar'

### DIFF
--- a/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
+++ b/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
@@ -129,11 +129,17 @@ public class MinijarFilter
             neededClasses.removeAll( removable );
             try
             {
+                // getRuntimeClasspathElements returns a list of
+                //  - the build output directory
+                //  - all the paths to the dependencies' jars
+                // We thereby need to ignore the build directory because we don't want
+                // to remove anything from it, as it's the starting point of the
+                // minification process.
                 for ( final String fileName : project.getRuntimeClasspathElements() )
                 {
-                    if ( new File( fileName ).isDirectory() )
+                    // Ignore the build directory from this project
+                    if ( fileName.equals( project.getBuild().getOutputDirectory() ) )
                     {
-                        log.debug( "Not a JAR file candidate. Ignoring classpath element '" + fileName + "'." );
                         continue;
                     }
                     if ( removeServicesFromJar( cp, neededClasses, fileName ) )
@@ -184,7 +190,7 @@ public class MinijarFilter
         }
         catch ( final IOException e )
         {
-            log.warn( e.getMessage() );
+            log.warn( "Not a JAR file candidate. Ignoring classpath element '" + fileName + "' (" + e + ")." );
         }
         return repeatScan;
     }

--- a/src/test/java/org/apache/maven/plugins/shade/filter/MinijarFilterTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/filter/MinijarFilterTest.java
@@ -28,6 +28,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -38,12 +44,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.TreeSet;
 
 public class MinijarFilterTest
 {
@@ -166,27 +166,22 @@ public class MinijarFilterTest
     }
 
     /**
-     * Check that the algorithm that removes services does not consider directories comming from the
-     * classpath as jar file candidates.
-     * 
-     * @see https://issues.apache.org/jira/browse/MSHADE-366
+     * Verify that directories are ignored when scanning the classpath for JARs containing services,
+     * but warnings are logged instead
+     *
+     * @see <a href="https://issues.apache.org/jira/browse/MSHADE-366">MSHADE-366</a>
      */
     @Test
-    public void remove_services_ignores_directories() throws Exception {
-        MavenProject mockedProject = mockProject(emptyFile, tempFolder.getRoot().getAbsolutePath());
-
-        new MinijarFilter(mockedProject, log);
-
-        verify(log, never()).warn(logCaptor.capture());
-    }
-
-    @Test
-    public void remove_services_logs_ignored_items() throws Exception {
+    public void removeServicesShouldIgnoreDirectories() throws Exception {
         String classPathElementToIgnore = tempFolder.getRoot().getAbsolutePath();
         MavenProject mockedProject = mockProject(emptyFile, classPathElementToIgnore);
 
         new MinijarFilter(mockedProject, log);
 
-        verify(log, times(1)).debug("Not a JAR file candidate. Ignoring classpath element '" + classPathElementToIgnore + "'.");
+        verify(log, never()).warn(logCaptor.capture());
+        verify(log, times(1)).debug(
+            "Not a JAR file candidate. Ignoring classpath element '" + classPathElementToIgnore + "'."
+        );
     }
+
 }

--- a/src/test/java/org/apache/maven/plugins/shade/filter/MinijarFilterTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/filter/MinijarFilterTest.java
@@ -20,39 +20,48 @@ package org.apache.maven.plugins.shade.filter;
  */
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Set;
-import java.util.TreeSet;
-
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+
 public class MinijarFilterTest
 {
 
+    @Rule
+    public TemporaryFolder tempFolder = TemporaryFolder.builder().assureDeletion().build();
+
     private File emptyFile;
+    private Log log;
+    private ArgumentCaptor<CharSequence> logCaptor;
 
     @Before
     public void init()
         throws IOException
     {
-        TemporaryFolder tempFolder = new TemporaryFolder();
-        tempFolder.create();
         this.emptyFile = tempFolder.newFile();
-
+        this.log = mock(Log.class);
+        logCaptor = ArgumentCaptor.forClass(CharSequence.class);
     }
 
     /**
@@ -64,11 +73,7 @@ public class MinijarFilterTest
     {
         assumeFalse( "Expected to run under JDK8+", System.getProperty("java.version").startsWith("1.7") );
 
-        ArgumentCaptor<CharSequence> logCaptor = ArgumentCaptor.forClass( CharSequence.class );
-
         MavenProject mavenProject = mockProject( emptyFile );
-
-        Log log = mock( Log.class );
 
         MinijarFilter mf = new MinijarFilter( mavenProject, log );
 
@@ -84,13 +89,9 @@ public class MinijarFilterTest
     public void testWithPomProject()
         throws IOException
     {
-        ArgumentCaptor<CharSequence> logCaptor = ArgumentCaptor.forClass( CharSequence.class );
-
         // project with pom packaging and no artifact.
         MavenProject mavenProject = mockProject( null );
         mavenProject.setPackaging( "pom" );
-
-        Log log = mock( Log.class );
 
         MinijarFilter mf = new MinijarFilter( mavenProject, log );
 
@@ -105,7 +106,7 @@ public class MinijarFilterTest
 
     }
 
-    private MavenProject mockProject( File file )
+    private MavenProject mockProject( File file, String... classPathElements )
     {
         MavenProject mavenProject = mock( MavenProject.class );
 
@@ -129,17 +130,18 @@ public class MinijarFilterTest
 
         when( mavenProject.getArtifact().getFile() ).thenReturn( file );
 
-        return mavenProject;
+        try {
+            when(mavenProject.getRuntimeClasspathElements()).thenReturn(Arrays.asList(classPathElements));
+        } catch (DependencyResolutionRequiredException e) {
+            fail("Encountered unexpected exception: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
 
+        return mavenProject;
     }
 
     @Test
     public void finsishedShouldProduceMessageForClassesTotalNonZero()
     {
-        ArgumentCaptor<CharSequence> logCaptor = ArgumentCaptor.forClass( CharSequence.class );
-
-        Log log = mock( Log.class );
-
         MinijarFilter m = new MinijarFilter( 1, 50, log );
 
         m.finished();
@@ -153,10 +155,6 @@ public class MinijarFilterTest
     @Test
     public void finishedShouldProduceMessageForClassesTotalZero()
     {
-        ArgumentCaptor<CharSequence> logCaptor = ArgumentCaptor.forClass( CharSequence.class );
-
-        Log log = mock( Log.class );
-
         MinijarFilter m = new MinijarFilter( 0, 0, log );
 
         m.finished();
@@ -165,5 +163,30 @@ public class MinijarFilterTest
 
         assertEquals( "Minimized 0 -> 0", logCaptor.getValue() );
 
+    }
+
+    /**
+     * Check that the algorithm that removes services does not consider directories comming from the
+     * classpath as jar file candidates.
+     * 
+     * @see https://issues.apache.org/jira/browse/MSHADE-366
+     */
+    @Test
+    public void remove_services_ignores_directories() throws Exception {
+        MavenProject mockedProject = mockProject(emptyFile, tempFolder.getRoot().getAbsolutePath());
+
+        new MinijarFilter(mockedProject, log);
+
+        verify(log, never()).warn(logCaptor.capture());
+    }
+
+    @Test
+    public void remove_services_logs_ignored_items() throws Exception {
+        String classPathElementToIgnore = tempFolder.getRoot().getAbsolutePath();
+        MavenProject mockedProject = mockProject(emptyFile, classPathElementToIgnore);
+
+        new MinijarFilter(mockedProject, log);
+
+        verify(log, times(1)).debug("Not a JAR file candidate. Ignoring classpath element '" + classPathElementToIgnore + "'.");
     }
 }


### PR DESCRIPTION
Follow-up on #104 and #83.
JIRA: https://issues.apache.org/jira/browse/MSHADE-366

The fact that the build output directory has to be handled is legit because the minifier calls `project.getRuntimeClassPathElements()` which returns a list of the project output dir and all dependencies jars.  It has to be handled specifically.  Any other directory will print a warning as currently.

It could be considered to switch the call to `project.getRuntimeClassPathElements()` to another call but that seems out of scope for this bug fix PR.