### PR TITLE
[MSHADE-438] Update to Maven 3.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.1.1</mavenVersion>
+    <mavenVersion>3.2.5</mavenVersion>
     <javaVersion>8</javaVersion>
     <sisu.version>0.3.5</sisu.version>
     <currentVersion>${project.version}</currentVersion>
@@ -160,18 +160,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
-      <version>0.13.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-inject-plexus</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
     <!-- Others -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -202,7 +190,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.vafer</groupId>
@@ -212,7 +200,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.2</version>
+      <version>4.3</version>
     </dependency>
 
     <!-- Test -->
@@ -256,6 +244,18 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-testing</groupId>
+      <artifactId>maven-plugin-testing-harness</artifactId>
+      <version>3.3.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/it/projects/MSHADE-340_shadedTestJarArtifactAttached/pom.xml
+++ b/src/it/projects/MSHADE-340_shadedTestJarArtifactAttached/pom.xml
@@ -81,9 +81,10 @@ under the License.
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>default-source</id>
                         <goals>
-                            <goal>jar</goal>
-                            <goal>test-jar</goal>
+                            <goal>jar-no-fork</goal>
+                            <goal>test-jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -92,6 +93,7 @@ under the License.
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>default-jar</id>
                         <goals>
                             <goal>jar</goal>
                             <goal>test-jar</goal>

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -19,15 +19,14 @@ package org.apache.maven.plugins.shade.mojo;
  * under the License.
  */
 
+import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Exclusion;
 import org.apache.maven.model.Model;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -52,19 +51,21 @@ import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
-import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.WriterFactory;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.ArtifactType;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -103,42 +104,6 @@ public class ShadeMojo
      */
     @Parameter( defaultValue = "${project}", readonly = true, required = true )
     private MavenProject project;
-
-    @Component
-    private MavenProjectHelper projectHelper;
-
-    @Component( hint = "default", role = org.apache.maven.plugins.shade.Shader.class )
-    private Shader shader;
-
-    /**
-     * The dependency graph builder to use.
-     */
-    @Component
-    private DependencyGraphBuilder dependencyGraphBuilder;
-
-    /**
-     * ProjectBuilder, needed to create projects from the artifacts.
-     */
-    @Component
-    private ProjectBuilder projectBuilder;
-
-    /**
-     * Remote repositories which will be searched for source attachments.
-     */
-    @Parameter( readonly = true, required = true, defaultValue = "${project.remoteArtifactRepositories}" )
-    protected List<ArtifactRepository> remoteArtifactRepositories;
-
-    /**
-     * Local maven repository.
-     */
-    @Parameter( readonly = true, required = true, defaultValue = "${localRepository}" )
-    protected ArtifactRepository localRepository;
-
-    /**
-     * Artifact resolver, needed to download source jars for inclusion in classpath.
-     */
-    @Component
-    protected ArtifactResolver artifactResolver;
 
     /**
      * Artifacts to include/exclude from the final artifact. Artifacts are denoted by composite identifiers of the
@@ -390,21 +355,43 @@ public class ShadeMojo
     private boolean shadeTestJar;
 
     /**
+     * When true, skips the execution of this MOJO.
+     * @since 3.3.0
+     */
+    @Parameter( defaultValue = "false" )
+    private boolean skip;
+
+    @Inject
+    private MavenProjectHelper projectHelper;
+
+    @Inject
+    private Shader shader;
+
+    @Inject
+    private RepositorySystem repositorySystem;
+
+    /**
+     * The dependency graph builder to use.
+     */
+    @Inject
+    private DependencyGraphBuilder dependencyGraphBuilder;
+
+    /**
+     * ProjectBuilder, needed to create projects from the artifacts.
+     */
+    @Inject
+    private ProjectBuilder projectBuilder;
+
+    /**
      * All the present Shaders.
      */
     @Inject
     private Map<String, Shader> shaders;
 
     /**
-     * When true, skips the execution of this MOJO.
-     * @since 3.3.0
-     */
-    @Parameter( defaultValue = "false" )
-    private boolean skip;
-    
-    /**
      * @throws MojoExecutionException in case of an error.
      */
+    @Override
     public void execute()
         throws MojoExecutionException
     {
@@ -846,8 +833,8 @@ public class ShadeMojo
     private void copyFiles( File source, File target )
         throws IOException
     {
-        try ( InputStream in = new FileInputStream( source );
-              OutputStream out = new FileOutputStream( target ) )
+        try ( InputStream in = Files.newInputStream( source.toPath() );
+              OutputStream out = Files.newOutputStream( target.toPath() ) )
         {
             IOUtil.copy( in, out );
         }
@@ -855,20 +842,20 @@ public class ShadeMojo
 
     private File resolveArtifactForClassifier( Artifact artifact, String classifier )
     {
-        DefaultArtifactCoordinate coordinate = new DefaultArtifactCoordinate();
-        coordinate.setGroupId( artifact.getGroupId() );
-        coordinate.setArtifactId( artifact.getArtifactId() );
-        coordinate.setVersion( artifact.getVersion() );
-        coordinate.setExtension( "jar" );
-        coordinate.setClassifier( classifier );
+        ArtifactType artifactType = session.getRepositorySession().getArtifactTypeRegistry().get( artifact.getType() );
+        org.eclipse.aether.artifact.DefaultArtifact coordinate = new DefaultArtifact( artifact.getGroupId(),
+                artifact.getArtifactId(), classifier, artifactType.getExtension(), artifact.getVersion(),
+                null, artifactType );
+        ArtifactRequest request = new ArtifactRequest(
+                coordinate, RepositoryUtils.toRepos( project.getRemoteArtifactRepositories() ), "shade" );
 
         Artifact resolvedArtifact;
         try
         {
-            resolvedArtifact =
-                artifactResolver.resolveArtifact( session.getProjectBuildingRequest(), coordinate ).getArtifact();
+            ArtifactResult result = repositorySystem.resolveArtifact( session.getRepositorySession(), request );
+            resolvedArtifact = RepositoryUtils.toArtifact( result.getArtifact() );
         }
-        catch ( ArtifactResolverException e )
+        catch ( ArtifactResolutionException e )
         {
             getLog().warn( "Could not get " + classifier + " for " + artifact );
             return null;
@@ -1216,8 +1203,8 @@ public class ShadeMojo
 
                 ProjectBuildingRequest projectBuildingRequest =
                     new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
-                projectBuildingRequest.setLocalRepository( localRepository );
-                projectBuildingRequest.setRemoteRepositories( remoteArtifactRepositories );
+                projectBuildingRequest.setLocalRepository( session.getLocalRepository() );
+                projectBuildingRequest.setRemoteRepositories( project.getRemoteArtifactRepositories() );
 
                 ProjectBuildingResult result = projectBuilder.build( f, projectBuildingRequest );
 

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -21,6 +21,7 @@ package org.apache.maven.plugins.shade.mojo;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Exclusion;
@@ -54,8 +55,6 @@ import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.WriterFactory;
 import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.artifact.ArtifactType;
-import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
@@ -842,12 +841,15 @@ public class ShadeMojo
 
     private File resolveArtifactForClassifier( Artifact artifact, String classifier )
     {
-        ArtifactType artifactType = session.getRepositorySession().getArtifactTypeRegistry().get( artifact.getType() );
-        org.eclipse.aether.artifact.DefaultArtifact coordinate = new DefaultArtifact( artifact.getGroupId(),
-                artifact.getArtifactId(), classifier, artifactType.getExtension(), artifact.getVersion(),
-                null, artifactType );
-        ArtifactRequest request = new ArtifactRequest(
-                coordinate, RepositoryUtils.toRepos( project.getRemoteArtifactRepositories() ), "shade" );
+        org.eclipse.aether.artifact.Artifact coordinate = RepositoryUtils.toArtifact(
+                new DefaultArtifact( artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersionRange(),
+                        artifact.getScope(), artifact.getType(), classifier, artifact.getArtifactHandler(),
+                        artifact.isOptional()
+                )
+        );
+
+        ArtifactRequest request = new ArtifactRequest( coordinate,
+                RepositoryUtils.toRepos( project.getRemoteArtifactRepositories() ), "shade" );
 
         Artifact resolvedArtifact;
         try


### PR DESCRIPTION
Up the baseline as for the rest of ASF plugins.

Changes:
* drop MAT
* drop uses of archaic constructs

Also update IT for MSHADE-340 as it was not passing with maven-jar-plugin 3+ version (maven 3.8.x used maven-jar-plugin 2.4), as the IT was replacing the main JAR intentionally, or unintentionally.

---

https://issues.apache.org/jira/browse/MSHADE-438
