### PR TITLE
[MSHADE-440] Reproduce problem in IT.

### DIFF
--- a/src/it/projects/MSHADE-440-DRP-variables-in-profile/invoker.properties
+++ b/src/it/projects/MSHADE-440-DRP-variables-in-profile/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.profiles = activeProfile
+invoker.goals = clean package

--- a/src/it/projects/MSHADE-440-DRP-variables-in-profile/pom.xml
+++ b/src/it/projects/MSHADE-440-DRP-variables-in-profile/pom.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.drp</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0</version>
+
+  <name>MSHADE-xxx</name>
+  <description>
+    Test variable in a profile.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
+    <prop>CHECK Outside profile ${project.basedir}.</prop>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.shade.drp</groupId>
+      <artifactId>a</artifactId>
+      <version>0.1</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>activeProfile</id>
+      <properties>
+        <prop>CHECK Inside active profile ${project.basedir}.</prop>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>CHECK Inside active profile ${project.basedir}.</id>
+                <configuration>
+                  <testOutputDirectory>CHECK Inside active profile ${project.basedir}.</testOutputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>inactiveProfile</id>
+      <properties>
+        <prop>CHECK Inside inactive profile ${project.basedir}.</prop>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>CHECK Inside inactive profile ${project.basedir}.</id>
+                <configuration>
+                  <testOutputDirectory>CHECK Inside inactive profile ${project.basedir}.</testOutputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+
+  </profiles>
+
+  <build>
+    <defaultGoal>clean package</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>run-shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>CHECK Outside profile ${project.basedir}.</id>
+            <configuration>
+              <testOutputDirectory>CHECK Outside profile ${project.basedir}.</testOutputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-440-DRP-variables-in-profile/verify.groovy
+++ b/src/it/projects/MSHADE-440-DRP-variables-in-profile/verify.groovy
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+// The problem situation that is recreated is that in some places in a DRP
+// properties are being expanded to their full values in an active profile.
+// The exact same code fragment outside of a profile is left untouched.
+
+File pomFile = new File( basedir, "dependency-reduced-pom.xml" )
+assert pomFile.isFile()
+
+content = pomFile.text
+
+assert content.contains( '<id>CHECK Outside profile ${project.basedir}.</id>' )
+assert content.contains( '<id>CHECK Inside inactive profile ${project.basedir}.</id>' )
+assert content.contains( '<id>CHECK Inside active profile ${project.basedir}.</id>' )
+
+assert content.contains( '<testOutputDirectory>CHECK Outside profile ${project.basedir}.</testOutputDirectory>' )
+assert content.contains( '<testOutputDirectory>CHECK Inside inactive profile ${project.basedir}.</testOutputDirectory>' )
+assert content.contains( '<testOutputDirectory>CHECK Inside active profile ${project.basedir}.</testOutputDirectory>' )
+
+assert content.contains( '<prop>CHECK Outside profile ${project.basedir}.</prop>' )
+assert content.contains( '<prop>CHECK Inside inactive profile ${project.basedir}.</prop>' )
+assert content.contains( '<prop>CHECK Inside active profile ${project.basedir}.</prop>' )


### PR DESCRIPTION
This is currently ONLY the reproduction of this problem.

Essentially if your run maven shade with an active profile then in some places within that profile properties are expanded to their full value.
I ran into this because by build was no longer reproducible outside of my machine because in the pom.xml packaged in the project the full path had been expanded.


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] [JIRA issue](https://issues.apache.org/jira/browse/MSHADE-440).
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHADE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHADE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

