### PR TITLE
[MNG-6829] Replace StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/it/projects/MSHADE-36-inject-dep-reduced-pom-in-final/src/main/java/com/example/Main.java
+++ b/src/it/projects/MSHADE-36-inject-dep-reduced-pom-in-final/src/main/java/com/example/Main.java
@@ -19,8 +19,6 @@
 
 package com.example;
 
-import org.codehaus.plexus.util.StringUtils;
-
 public class Main
 {
     public static void main( String[] args ) {
@@ -28,6 +26,6 @@ public class Main
     }
 
     public static boolean isEmpty( String input ) {
-        return StringUtils.isEmpty( input );
+        return input == null || input.isEmpty();
     }
 }

--- a/src/it/projects/MSHADE-36-inject-dep-reduced-pom-in-final/src/main/java/com/example/Main.java
+++ b/src/it/projects/MSHADE-36-inject-dep-reduced-pom-in-final/src/main/java/com/example/Main.java
@@ -19,6 +19,8 @@
 
 package com.example;
 
+import org.codehaus.plexus.util.StringUtils;
+
 public class Main
 {
     public static void main( String[] args ) {
@@ -26,6 +28,6 @@ public class Main
     }
 
     public static boolean isEmpty( String input ) {
-        return input == null || input.isEmpty();
+        return StringUtils.isEmpty( input );
     }
 }

--- a/src/main/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformer.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformer.java
@@ -36,7 +36,6 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
 import org.apache.maven.plugins.shade.relocation.Relocator;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Merges <code>META-INF/NOTICE.TXT</code> files.
@@ -106,7 +105,7 @@ public class ApacheNoticeResourceTransformer extends AbstractCompatibilityTransf
         }
 
         BufferedReader reader;
-        if (StringUtils.isNotEmpty(encoding)) {
+        if (encoding != null && !encoding.isEmpty()) {
             reader = new BufferedReader(new InputStreamReader(is, encoding));
         } else {
             reader = new BufferedReader(new InputStreamReader(is));
@@ -178,7 +177,7 @@ public class ApacheNoticeResourceTransformer extends AbstractCompatibilityTransf
         jos.putNextEntry(jarEntry);
 
         Writer writer;
-        if (StringUtils.isNotEmpty(encoding)) {
+        if (encoding != null && !encoding.isEmpty()) {
             writer = new OutputStreamWriter(jos, encoding);
         } else {
             writer = new OutputStreamWriter(jos);

--- a/src/main/java/org/apache/maven/plugins/shade/resource/DontIncludeResourceTransformer.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/DontIncludeResourceTransformer.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.jar.JarOutputStream;
 
 import org.apache.maven.plugins.shade.relocation.Relocator;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * A resource processor that prevents the inclusion of an arbitrary
@@ -36,7 +35,7 @@ public class DontIncludeResourceTransformer extends AbstractCompatibilityTransfo
     List<String> resources;
 
     public boolean canTransformResource(String r) {
-        if (StringUtils.isNotEmpty(resource) && r.endsWith(resource)) {
+        if ((resource != null && !resource.isEmpty()) && r.endsWith(resource)) {
             return true;
         }
 


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu