### PR TITLE
Get rid of security alerts

### DIFF
--- a/src/it/projects/MSHADE-105/bundle/pom.xml
+++ b/src/it/projects/MSHADE-105/bundle/pom.xml
@@ -42,7 +42,7 @@ under the License.
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.1.0</version>
+        <version>5.1.9</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/src/it/projects/MSHADE-105/shaded-jar/pom.xml
+++ b/src/it/projects/MSHADE-105/shaded-jar/pom.xml
@@ -30,7 +30,7 @@ under the License.
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.4</version>
+      <version>2.13.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/it/projects/MSHADE-36-inject-dep-reduced-pom-in-final/pom.xml
+++ b/src/it/projects/MSHADE-36-inject-dep-reduced-pom-in-final/pom.xml
@@ -43,12 +43,12 @@ under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>4.13.2</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>1.4.1</version>
+      <version>3.5.1</version>
     </dependency>
   </dependencies>
 

--- a/src/it/projects/MSHADE-36-inject-dep-reduced-pom-in-final/verify.bsh
+++ b/src/it/projects/MSHADE-36-inject-dep-reduced-pom-in-final/verify.bsh
@@ -25,13 +25,13 @@ import org.codehaus.plexus.util.*;
 String[] wanted =
 {
     "com/example/Main.class",
-    "junit/swingui/icons/error.gif",
+    "junit/runner/logo.gif",
     "com/example/shaded/org/codehaus/plexus/util/StringUtils.class",
 };
 
 String[] unwanted =
 {
-    "junit/swingui/TestRunner.class",
+    "junit/textui/TestRunner.class",
     "org/codehaus/plexus/util/StringUtils.class",
 };
 

--- a/src/it/projects/MSHADE-391_noRelocationKeepOriginalClasses/pom.xml
+++ b/src/it/projects/MSHADE-391_noRelocationKeepOriginalClasses/pom.xml
@@ -34,7 +34,7 @@ under the License.
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/src/it/projects/mini-jar-respect-includes/pom.xml
+++ b/src/it/projects/mini-jar-respect-includes/pom.xml
@@ -36,13 +36,13 @@ under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>4.13.2</version>
     </dependency>
 
     <dependency>
       <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
-      <version>2.0.2</version>
+      <artifactId>jdom2</artifactId>
+      <version>2.0.6.1</version>
     </dependency>
     
     <dependency>
@@ -86,7 +86,7 @@ under the License.
                 </filter>
                 <!-- make sure that include patterns only affect their specified artifacts -->
                 <filter>
-                  <artifact>org.jdom:jdom</artifact>
+                  <artifact>org.jdom:jdom2</artifact>
                   <includes>
                     <include>**</include>
                   </includes>

--- a/src/it/projects/mini-jar-respect-includes/verify.bsh
+++ b/src/it/projects/mini-jar-respect-includes/verify.bsh
@@ -31,7 +31,6 @@ String[] wanted =
 String[] unwanted =
 {
     "junit/textui/TestRunner.class",
-    "junit/textui/TestRunner.class",
     "org/objectweb/asm/Type.class"
 };
 

--- a/src/it/projects/mini-jar-respect-includes/verify.bsh
+++ b/src/it/projects/mini-jar-respect-includes/verify.bsh
@@ -23,14 +23,14 @@ String[] wanted =
 {
     "Main.class",
     "junit/framework/TestCase.class",
-    "junit/swingui/icons/error.gif",
-    "junit/awtui/TestRunner.class",
+    "junit/runner/logo.gif",
+    "junit/framework/Assert.class",
     "org/jdom2/Document.class"
 };
 
 String[] unwanted =
 {
-    "junit/swingui/TestRunner.class",
+    "junit/textui/TestRunner.class",
     "junit/textui/TestRunner.class",
     "org/objectweb/asm/Type.class"
 };

--- a/src/it/projects/project-with-reactors-included/pom.xml
+++ b/src/it/projects/project-with-reactors-included/pom.xml
@@ -46,7 +46,7 @@ under the License.
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.10</version>
+        <version>4.13.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/src/it/projects/shading-with-java-8-sources/pom.xml
+++ b/src/it/projects/shading-with-java-8-sources/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.7</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/it/projects/shading-with-release-sources/pom.xml
+++ b/src/it/projects/shading-with-release-sources/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.7</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/it/projects/users-shader-impl/pom.xml
+++ b/src/it/projects/users-shader-impl/pom.xml
@@ -45,7 +45,7 @@ under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.7</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This is cosmetic only (no plugin code or dependency change) only for ITs. As ITs contains POMs with old dependencies that do trigger security alerts (despite they are harmless). Get rid of them as they look bad.