### PR TITLE
[MSHADE-452]Fix ServiceResourceTransformer not correct issue.

### DIFF
--- a/src/main/java/org/apache/maven/plugins/shade/relocation/SimpleRelocator.java
+++ b/src/main/java/org/apache/maven/plugins/shade/relocation/SimpleRelocator.java
@@ -222,7 +222,7 @@ public class SimpleRelocator implements Relocator {
         StringBuilder shadedSourceContent = new StringBuilder(sourceContent.length() * 11 / 10);
         boolean isFirstSnippet = true;
         // Make sure that search pattern starts at word boundary and that we look for literal ".", not regex jokers
-        String[] snippets = sourceContent.split("\\b" + patternFrom.replace(".", "[.]") + "\\b");
+        String[] snippets = sourceContent.split("\\b" + patternFrom.replace(".", "[.]"));
         for (int i = 0, snippetsLength = snippets.length; i < snippetsLength; i++) {
             String snippet = snippets[i];
             String previousSnippet = isFirstSnippet ? "" : snippets[i - 1];

--- a/src/test/java/org/apache/maven/plugins/shade/resource/ServiceResourceTransformerTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/resource/ServiceResourceTransformerTest.java
@@ -54,7 +54,7 @@ public class ServiceResourceTransformerTest {
                 new SimpleRelocator("org.foo", "borg.foo", null, Arrays.asList("org.foo.exclude.*"));
         relocators.add(relocator);
 
-        String content = "org.foo.Service\norg.foo.exclude.OtherService\n";
+        String content = "org.foo.Service\norg.foo.exclude.OtherService\norg.fooPart.exclude.OtherService\n";
         byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
         InputStream contentStream = new ByteArrayInputStream(contentBytes);
         String contentResource = "META-INF/services/org.foo.something.another";
@@ -76,7 +76,10 @@ public class ServiceResourceTransformerTest {
             assertNotNull(jarEntry);
             try (InputStream entryStream = jarFile.getInputStream(jarEntry)) {
                 String xformedContent = IOUtils.toString(entryStream, "utf-8");
-                assertEquals("borg.foo.Service" + NEWLINE + "org.foo.exclude.OtherService" + NEWLINE, xformedContent);
+                assertEquals(
+                        "borg.foo.Service" + NEWLINE + "org.foo.exclude.OtherService" + NEWLINE
+                                + "borg.fooPart.exclude.OtherService" + NEWLINE,
+                        xformedContent);
             } finally {
                 jarFile.close();
             }


### PR DESCRIPTION
# Background
We have java path as below
- org.apache.demo1
- org.apache.demo2

In `maven-shade-plugin 3.2.1`, we use relocation to process path and SPI Service file at the same time, and we will follow result.
```
<relocation>
    <pattern>org.apache.demo</pattern>
    <shadedPattern>shaded.org.apache.demo</shadedPattern>
</relocation> 
```
```
META-INF/services/shaded.org.apache.demo
```

But in `maven-shaded-plugin 3.5.0`, it can't work as before, alouthght it SPI file name alao could be changed, but the SPI file content will have no change.

I compared the differneces between the `maven-shaded-plugin 3.5.0` and `maven-shaded-plugin 3.2.1`, finally find in `maven-shaded-plugin 3.2.1`, file content changed by follow code

```
public String applyToSourceContent( String sourceContent )
{
    if ( rawString )
    {
        return sourceContent;
    }
    else
    {
        return sourceContent.replaceAll( "\\b" + pattern, shadedPattern );
    }
}
```
but in ```maven-shaded-plugin 3.5.0```, the code change to 
```
private String shadeSourceWithExcludes( String sourceContent, String patternFrom, String patternTo,
                                        Set<String> excludedPatterns )
{
    // Usually shading makes package names a bit longer, so make buffer 10% bigger than original source
    StringBuilder shadedSourceContent = new StringBuilder( sourceContent.length() * 11 / 10 );
    boolean isFirstSnippet = true;
    // Make sure that search pattern starts at word boundary and we look for literal ".", not regex jokers
    for ( String snippet : sourceContent.split( "\\b" + patternFrom.replace( ".", "[.]" + "\\b" ) ) )
    {
        boolean doExclude = false;
        for ( String excludedPattern : excludedPatterns )
        {
            if ( snippet.startsWith( excludedPattern ) )
            {
                doExclude = true;
                break;
            }
        }
        if ( isFirstSnippet )
        {
            shadedSourceContent.append( snippet );
            isFirstSnippet = false;
    }
        else
        {
            shadedSourceContent.append( doExclude ? patternFrom : patternTo ).append( snippet );
        }
    }
    return shadedSourceContent.toString();
} 
```

In my cases, source content is `org.apache.demo1`, pattern from is `org.apache.demo`, pattern to is `shaded.org.apache.demo`.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHADE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHADE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHADE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

