### PR TITLE
Avoid double "up to" when rendered

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
                 <jdk>5</jdk>
               </requirementsHistory>
               <requirementsHistory>
-                <version>up to 1.4</version>
+                <version>from 1.0 to 1.4</version>
                 <maven>2.0.6</maven>
                 <jdk>1.4</jdk>
               </requirementsHistory>


### PR DESCRIPTION
@hboutemy see https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven-dist-tool/job/master/site/dist-tool-prerequisites.html which currently says "up to up to 1.4 requires Maven 2.0.6 + JDK 4"


