### PR TITLE
Drop the cruft

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,4 +26,3 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
     with:
           ff-jdk: "21"
-          ff-jdk-distribution: "corretto"

--- a/pom.xml
+++ b/pom.xml
@@ -177,11 +177,6 @@
       <version>2.0.6.1</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-dependency-tree</artifactId>
-      <version>3.2.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <version>1.26.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
   </contributors>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <scm>
@@ -79,12 +79,11 @@
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.6.3</mavenVersion>
+    <mavenVersion>3.9.7</mavenVersion>
     <javaVersion>8</javaVersion>
-    <sisu.version>0.3.5</sisu.version>
     <currentVersion>${project.version}</currentVersion>
     <asmVersion>9.7</asmVersion>
-    <slf4j.version>1.7.32</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <project.build.outputTimestamp>2024-04-20T15:33:41Z</project.build.outputTimestamp>
   </properties>
 
@@ -93,12 +92,12 @@
       <dependency>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.inject</artifactId>
-        <version>${sisu.version}</version>
+        <version>${version.sisu-maven-plugin}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.plexus</artifactId>
-        <version>${sisu.version}</version>
+        <version>${version.sisu-maven-plugin}</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>
@@ -144,10 +143,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-xml</artifactId>
+      <version>3.5.1</version>
     </dependency>
 
     <!-- DI -->
@@ -186,19 +182,19 @@
       <version>3.2.1</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.26.2</version>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.13.0</version>
+      <version>2.16.1</version>
     </dependency>
     <dependency>
       <groupId>org.vafer</groupId>
       <artifactId>jdependency</artifactId>
       <version>2.10</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-      <version>4.4</version>
     </dependency>
 
     <!-- Test -->
@@ -228,13 +224,13 @@
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-legacy</artifactId>
-      <version>2.9.1</version>
+      <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>3.12.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -254,11 +250,6 @@
       <artifactId>maven-plugin-testing-harness</artifactId>
       <version>3.3.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>1.26.1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,26 +87,6 @@
     <project.build.outputTimestamp>2024-04-20T15:33:41Z</project.build.outputTimestamp>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.eclipse.sisu</groupId>
-        <artifactId>org.eclipse.sisu.inject</artifactId>
-        <version>${version.sisu-maven-plugin}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.sisu</groupId>
-        <artifactId>org.eclipse.sisu.plexus</artifactId>
-        <version>${version.sisu-maven-plugin}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.inject</groupId>
-        <artifactId>guice</artifactId>
-        <version>5.1.0</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <!-- Maven -->
     <dependency>
@@ -202,6 +182,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <version>5.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -1199,7 +1199,9 @@ public class ShadeMojo extends AbstractMojo {
                 String artifactId2 = getId(RepositoryUtils.toArtifact(n2.getArtifact()));
 
                 for (DependencyNode n3 : n2.getChildren()) {
+                    // stupid m-a Artifact that has no idea what it is: dependency or artifact?
                     Artifact artifact3 = RepositoryUtils.toArtifact(n3.getArtifact());
+                    artifact3.setScope(n3.getDependency().getScope());
                     String artifactId3 = getId(artifact3);
 
                     // check if it really isn't in the list of original dependencies. Maven

--- a/src/main/java/org/apache/maven/plugins/shade/resource/properties/io/NoCloseOutputStream.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/properties/io/NoCloseOutputStream.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * Simple output stream replacing close call by a simpe flush.
+ * Simple output stream replacing close call by a simple flush.
  * Useful for output streams nesting streams (like jar output streams) and using a stream encoder.
  */
 public class NoCloseOutputStream extends OutputStream {


### PR DESCRIPTION
Drop dependencies that are superfluous (one class used) or are deprecated:
* drop commons-collections4
* drop (to be deprecated) maven-dependency-tree

Slight updates and cleanup in dependencies.

---

https://issues.apache.org/jira/browse/MSHADE-473
https://issues.apache.org/jira/browse/MSHADE-474
https://issues.apache.org/jira/browse/MSHADE-475
https://issues.apache.org/jira/browse/MSHADE-476
https://issues.apache.org/jira/browse/MSHADE-477