### PR TITLE
Remove old note

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -53,10 +53,6 @@ ${project.name}
   {{{./scm.html}source repository}} and will find supplementary information in the
   {{{http://maven.apache.org/guides/development/guide-helping.html}guide to helping with Maven}}.
 
-* Version 3.2.0 Hints
-
-  If you like to use <<<minimizeJar>>> this means you have to use JDK8+. This
-  is based on a required upgrade of dependencies.
 
 * Examples
 


### PR DESCRIPTION
Java 8 is required everywhere by Maven these days

@michael-o 

