### PR TITLE
Reduce duplicate tests for ApacheNoticeResourceTransformer

### DIFF
--- a/src/test/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformerParameterTests.java
+++ b/src/test/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformerParameterTests.java
@@ -27,7 +27,6 @@ import org.apache.maven.plugins.shade.relocation.Relocator;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -41,15 +40,6 @@ public class ApacheNoticeResourceTransformerParameterTests {
     @Before
     public void setUp() {
         subject = new ApacheNoticeResourceTransformer();
-    }
-
-    @Test
-    public void testCanTransformResource() {
-        assertTrue(subject.canTransformResource("META-INF/NOTICE"));
-        assertTrue(subject.canTransformResource("META-INF/NOTICE.TXT"));
-        assertTrue(subject.canTransformResource("META-INF/NOTICE.md"));
-        assertTrue(subject.canTransformResource("META-INF/Notice.txt"));
-        assertTrue(subject.canTransformResource("META-INF/Notice.md"));
     }
 
     @Test

--- a/src/test/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformerTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformerTest.java
@@ -54,6 +54,7 @@ public class ApacheNoticeResourceTransformerTest {
         assertTrue(transformer.canTransformResource("META-INF/NOTICE.TXT"));
         assertTrue(transformer.canTransformResource("META-INF/NOTICE.md"));
         assertTrue(transformer.canTransformResource("META-INF/Notice.txt"));
+        assertTrue(transformer.canTransformResource("META-INF/Notice.md"));
         assertFalse(transformer.canTransformResource("META-INF/MANIFEST.MF"));
     }
 }


### PR DESCRIPTION
I missed that it's already in ApacheNoticeResourceTransformerTest.
Follow up #243, 


--------------

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHADE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MSHADE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHADE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

