### PR TITLE
Bump ASM 9.8 to support JDK 25 bytecode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <mavenVersion>3.9.7</mavenVersion>
     <javaVersion>8</javaVersion>
     <currentVersion>${project.version}</currentVersion>
-    <asmVersion>9.7</asmVersion>
+    <asmVersion>9.8</asmVersion>
     <slf4j.version>1.7.36</slf4j.version>
     <project.build.outputTimestamp>2024-05-28T15:16:00Z</project.build.outputTimestamp>
   </properties>


### PR DESCRIPTION
The current ASM 9.7 does not support JDK 24 and 25 bytecode.

```
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.6.0:shade (default) on project kyuubi-spark-sql-engine_2.12: Error creating shaded jar: Problem shading JAR /Users/chengpan/.m2/repository/net/bytebuddy/byte-buddy/1.17.6/byte-buddy-1.17.6.jar entry META-INF/versions/24/net/bytebuddy/jar/asmjdkbridge/JdkClassWriter$1.class: java.lang.IllegalArgumentException: Unsupported class file major version 68 -> [Help 1]
...
```
---

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

