### PR TITLE
Drop ASM; use already present one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,23 +82,12 @@
     <mavenVersion>3.9.12</mavenVersion>
     <javaVersion>8</javaVersion>
     <currentVersion>${project.version}</currentVersion>
-    <asmVersion>9.9.1</asmVersion>
     <slf4j.version>1.7.36</slf4j.version>
     <project.build.outputTimestamp>2025-09-10T00:53:43Z</project.build.outputTimestamp>
   </properties>
 
   <dependencies>
     <!-- Needed dependencies -->
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-      <version>${asmVersion}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-commons</artifactId>
-      <version>${asmVersion}</version>
-    </dependency>
     <dependency>
       <groupId>org.jdom</groupId>
       <artifactId>jdom2</artifactId>

--- a/src/it/projects/MSHADE-258_module_relocation/pom.xml
+++ b/src/it/projects/MSHADE-258_module_relocation/pom.xml
@@ -33,7 +33,7 @@ under the License.
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>@asmVersion@</version>
+      <version>9.9.1</version>
     </dependency>
   </dependencies>
 

--- a/src/it/projects/mini-jar-respect-includes/pom.xml
+++ b/src/it/projects/mini-jar-respect-includes/pom.xml
@@ -48,7 +48,7 @@ under the License.
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>@asmVersion@</version>
+      <version>9.9.1</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/apache/maven/plugins/shade/DefaultShader.java
+++ b/src/main/java/org/apache/maven/plugins/shade/DefaultShader.java
@@ -66,13 +66,13 @@ import org.apache.maven.plugins.shade.resource.ReproducibleResourceTransformer;
 import org.apache.maven.plugins.shade.resource.ResourceTransformer;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.io.CachingOutputStream;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.commons.ClassRemapper;
-import org.objectweb.asm.commons.Remapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.vafer.jdeb.shaded.objectweb.asm.ClassReader;
+import org.vafer.jdeb.shaded.objectweb.asm.ClassVisitor;
+import org.vafer.jdeb.shaded.objectweb.asm.ClassWriter;
+import org.vafer.jdeb.shaded.objectweb.asm.commons.ClassRemapper;
+import org.vafer.jdeb.shaded.objectweb.asm.commons.Remapper;
 
 /**
  * @author Jason van Zyl


### PR DESCRIPTION
Given `jdependency` is a **key dependency** of this plugin, and it already have full ASM shaded in, why not use it?

See
https://github.com/tcurdt/jdependency/issues/389

THIS IS JUST EXPERIMENT and pro-con discussion starter
