### PR TITLE
[MSHADE-260] shading does not rewrite Lambda deserializers

### DIFF
--- a/src/it/projects/MSHADE-260-reloc-serialized-lambda/README.txt
+++ b/src/it/projects/MSHADE-260-reloc-serialized-lambda/README.txt
@@ -1,0 +1,56 @@
+# Serialized Lambda Relocation Test
+
+This integration test verifies that the maven-shade-plugin correctly rewrites
+serialized lambda metadata when relocating classes.
+
+## Background
+
+When a lambda expression or method reference uses a `Serializable` functional
+interface, the Java compiler generates a `SerializedLambda` object that contains
+metadata about the lambda's implementation class. This metadata includes the
+class name, which must be rewritten during shading to reflect the relocated
+package structure.
+
+## Test Structure
+
+- **MapFunction.java** - A `Serializable` functional interface
+- **Main.java** - Uses a method reference (`processor::process`) that creates
+  a serialized lambda
+- **Processor.java** - Contains the method used as a method reference
+- **DataHolder.java** - Simple data class passed through the lambda
+
+## Configuration
+
+The test uses the `<shadeSerializedLambda>true</shadeSerializedLambda>` option:
+
+```xml
+<relocation>
+    <pattern>org.apache.maven.its.shade.reloc.lambda</pattern>
+    <shadedPattern>org.apache.maven.its.shade.reloc.shaded.lambda</shadedPattern>
+    <shadeSerializedLambda>true</shadeSerializedLambda>
+</relocation>
+```
+
+## What the Test Verifies
+
+1. All classes are relocated from `org.apache.maven.its.shade.reloc.lambda` to
+   `org.apache.maven.its.shade.reloc.shaded.lambda`
+2. The original package paths do NOT exist in the shaded JAR
+3. Most importantly: The serialized lambda metadata (in the bytecode's constant
+   pool) references the shaded package, not the original
+
+## Running the Test
+
+```bash
+cd /path/to/maven-shade-plugin
+mvn verify -Prun-its -Dinvoker.test=reloc-serialized-lambda
+```
+
+## Expected Behavior
+
+After shading:
+- `Main.class` should be at `org/apache/maven/its/shade/reloc/shaded/lambda/Main.class`
+- The bytecode should NOT contain references to the original package path
+  `org/apache/maven/its/shade/reloc/lambda/Processor`
+- All lambda metadata should use the shaded path
+  `org/apache/maven/its/shade/reloc/shaded/lambda/Processor`

--- a/src/it/projects/MSHADE-260-reloc-serialized-lambda/invoker.properties
+++ b/src/it/projects/MSHADE-260-reloc-serialized-lambda/invoker.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Lambdas were introduced in Java 8
+invoker.java.version = 1.8+
+
+# Run package goal to trigger shade
+invoker.goals = clean package

--- a/src/it/projects/MSHADE-260-reloc-serialized-lambda/pom.xml
+++ b/src/it/projects/MSHADE-260-reloc-serialized-lambda/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.reloc</groupId>
+  <artifactId>serialized-lambda</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <name>Serialized Lambda Relocation Test</name>
+  <description>
+    Test that serialized lambda metadata is properly relocated when shading.
+    This test uses a Serializable functional interface with a method reference
+    to ensure the lambda's captured class information is rewritten.
+  </description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.maven.its.shade.reloc.lambda</pattern>
+                  <shadedPattern>org.apache.maven.its.shade.reloc.shaded.lambda</shadedPattern>
+                  <shadeSerializedLambda>true</shadeSerializedLambda>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-260-reloc-serialized-lambda/src/main/java/org/apache/maven/its/shade/reloc/lambda/DataHolder.java
+++ b/src/it/projects/MSHADE-260-reloc-serialized-lambda/src/main/java/org/apache/maven/its/shade/reloc/lambda/DataHolder.java
@@ -16,48 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.plugins.shade.mojo;
-
-import java.util.List;
+package org.apache.maven.its.shade.reloc.lambda;
 
 /**
- * @author Jason van Zyl
- * @author Mauro Talevi
+ * A simple data class (record) used to demonstrate serialized lambda relocation.
  */
-public class PackageRelocation {
-    private String pattern;
+public class DataHolder {
+    private final String value;
 
-    private String shadedPattern;
-
-    private List<String> includes;
-
-    private List<String> excludes;
-
-    private boolean rawString;
-
-    private boolean shadeSerializedLambda;
-
-    public String getPattern() {
-        return pattern;
+    public DataHolder(String value) {
+        this.value = value;
     }
 
-    public String getShadedPattern() {
-        return shadedPattern;
-    }
-
-    public List<String> getIncludes() {
-        return includes;
-    }
-
-    public List<String> getExcludes() {
-        return excludes;
-    }
-
-    public boolean isRawString() {
-        return rawString;
-    }
-
-    public boolean isShadeSerializedLambda() {
-        return shadeSerializedLambda;
+    public String getValue() {
+        return value;
     }
 }

--- a/src/it/projects/MSHADE-260-reloc-serialized-lambda/src/main/java/org/apache/maven/its/shade/reloc/lambda/Main.java
+++ b/src/it/projects/MSHADE-260-reloc-serialized-lambda/src/main/java/org/apache/maven/its/shade/reloc/lambda/Main.java
@@ -16,48 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.plugins.shade.mojo;
-
-import java.util.List;
+package org.apache.maven.its.shade.reloc.lambda;
 
 /**
- * @author Jason van Zyl
- * @author Mauro Talevi
+ * Main class that uses a method reference with a Serializable functional interface.
+ * When compiled, this creates a serialized lambda that captures class metadata.
  */
-public class PackageRelocation {
-    private String pattern;
-
-    private String shadedPattern;
-
-    private List<String> includes;
-
-    private List<String> excludes;
-
-    private boolean rawString;
-
-    private boolean shadeSerializedLambda;
-
-    public String getPattern() {
-        return pattern;
+public class Main {
+    public static void main(String[] args) {
+        Processor processor = new Processor();
+        DataHolder data = new DataHolder("test");
+        
+        // This method reference creates a serialized lambda
+        String result = transform(data, processor::process);
+        System.out.println(result);
     }
 
-    public String getShadedPattern() {
-        return shadedPattern;
-    }
-
-    public List<String> getIncludes() {
-        return includes;
-    }
-
-    public List<String> getExcludes() {
-        return excludes;
-    }
-
-    public boolean isRawString() {
-        return rawString;
-    }
-
-    public boolean isShadeSerializedLambda() {
-        return shadeSerializedLambda;
+    public static String transform(DataHolder value, MapFunction<DataHolder, String> mapper) {
+        return mapper.map(value);
     }
 }

--- a/src/it/projects/MSHADE-260-reloc-serialized-lambda/src/main/java/org/apache/maven/its/shade/reloc/lambda/MapFunction.java
+++ b/src/it/projects/MSHADE-260-reloc-serialized-lambda/src/main/java/org/apache/maven/its/shade/reloc/lambda/MapFunction.java
@@ -16,48 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.plugins.shade.mojo;
+package org.apache.maven.its.shade.reloc.lambda;
 
-import java.util.List;
+import java.io.Serializable;
 
 /**
- * @author Jason van Zyl
- * @author Mauro Talevi
+ * A serializable functional interface that will cause lambdas/method references
+ * to have their class information stored in the serialized lambda metadata.
  */
-public class PackageRelocation {
-    private String pattern;
-
-    private String shadedPattern;
-
-    private List<String> includes;
-
-    private List<String> excludes;
-
-    private boolean rawString;
-
-    private boolean shadeSerializedLambda;
-
-    public String getPattern() {
-        return pattern;
-    }
-
-    public String getShadedPattern() {
-        return shadedPattern;
-    }
-
-    public List<String> getIncludes() {
-        return includes;
-    }
-
-    public List<String> getExcludes() {
-        return excludes;
-    }
-
-    public boolean isRawString() {
-        return rawString;
-    }
-
-    public boolean isShadeSerializedLambda() {
-        return shadeSerializedLambda;
-    }
+@FunctionalInterface
+public interface MapFunction<T, R> extends Serializable {
+    R map(T t);
 }

--- a/src/it/projects/MSHADE-260-reloc-serialized-lambda/src/main/java/org/apache/maven/its/shade/reloc/lambda/Processor.java
+++ b/src/it/projects/MSHADE-260-reloc-serialized-lambda/src/main/java/org/apache/maven/its/shade/reloc/lambda/Processor.java
@@ -16,48 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.plugins.shade.mojo;
-
-import java.util.List;
+package org.apache.maven.its.shade.reloc.lambda;
 
 /**
- * @author Jason van Zyl
- * @author Mauro Talevi
+ * Processor class that contains a method used as a method reference.
  */
-public class PackageRelocation {
-    private String pattern;
-
-    private String shadedPattern;
-
-    private List<String> includes;
-
-    private List<String> excludes;
-
-    private boolean rawString;
-
-    private boolean shadeSerializedLambda;
-
-    public String getPattern() {
-        return pattern;
-    }
-
-    public String getShadedPattern() {
-        return shadedPattern;
-    }
-
-    public List<String> getIncludes() {
-        return includes;
-    }
-
-    public List<String> getExcludes() {
-        return excludes;
-    }
-
-    public boolean isRawString() {
-        return rawString;
-    }
-
-    public boolean isShadeSerializedLambda() {
-        return shadeSerializedLambda;
+public class Processor {
+    public String process(DataHolder data) {
+        return "Processed: " + data.getValue();
     }
 }

--- a/src/it/projects/MSHADE-260-reloc-serialized-lambda/verify.groovy
+++ b/src/it/projects/MSHADE-260-reloc-serialized-lambda/verify.groovy
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.jar.*
+
+// Path to the shaded JAR
+File jarFile = new File(basedir, "target/serialized-lambda-1.0.jar")
+assert jarFile.exists() : "Shaded JAR not found: ${jarFile}"
+
+JarFile jar = new JarFile(jarFile)
+
+// Check 1: Verify shaded classes exist (with relocated package)
+def shadedClasses = [
+    "org/apache/maven/its/shade/reloc/shaded/lambda/Main.class",
+    "org/apache/maven/its/shade/reloc/shaded/lambda/Processor.class",
+    "org/apache/maven/its/shade/reloc/shaded/lambda/DataHolder.class",
+    "org/apache/maven/its/shade/reloc/shaded/lambda/MapFunction.class"
+]
+
+shadedClasses.each { path ->
+    assert jar.getEntry(path) != null : "Expected shaded class not found: ${path}"
+}
+
+// Check 2: Verify original classes do NOT exist (they should be relocated)
+def originalClasses = [
+    "org/apache/maven/its/shade/reloc/lambda/Main.class",
+    "org/apache/maven/its/shade/reloc/lambda/Processor.class",
+    "org/apache/maven/its/shade/reloc/lambda/DataHolder.class",
+    "org/apache/maven/its/shade/reloc/lambda/MapFunction.class"
+]
+
+originalClasses.each { path ->
+    assert jar.getEntry(path) == null : "Original class should have been relocated: ${path}"
+}
+
+// Check 3: Read the Main class bytes and verify serialized lambda metadata is relocated
+def mainEntry = jar.getJarEntry("org/apache/maven/its/shade/reloc/shaded/lambda/Main.class")
+if (mainEntry != null) {
+    def is = jar.getInputStream(mainEntry)
+    def baos = new ByteArrayOutputStream()
+    def buffer = new byte[1024]
+    int len
+    while ((len = is.read(buffer)) != -1) {
+        baos.write(buffer, 0, len)
+    }
+    is.close()
+    
+    // Convert class bytes to string for pattern searching
+    // The serialized lambda metadata should contain the SHADED package, not original
+    def classContent = new String(baos.toByteArray(), "ISO-8859-1")
+    
+    // Look for the SerializedLambda bootstrap method marker
+    // This appears in the bytecode when lambdas are used
+    if (classContent.contains("SerializedLambda")) {
+        // If we have SerializedLambda, verify the implementation class reference
+        // The implementation class should point to the shaded package
+        // Check that the original package name does NOT appear in serialized metadata
+        assert !classContent.contains("org/apache/maven/its/shade/reloc/lambda/Processor") :
+            "Serialized lambda metadata still contains original package path. " +
+            "The class reference should have been relocated to shaded package."
+
+        assert !classContent.contains("org/apache/maven/its/shade/reloc/lambda") :
+                "Serialized lambda metadata still contains original package path. " +
+                        "The class reference should have been relocated to shaded package."
+    }
+}
+
+// Check 4: Search all class files for any lingering original package references
+def entries = jar.entries()
+boolean foundSerializedLambdaMetadata = false
+while (entries.hasMoreElements()) {
+    def entry = entries.nextElement()
+    if (entry.getName().endsWith(".class")) {
+        def is = jar.getInputStream(entry)
+        def baos = new ByteArrayOutputStream()
+        def buffer = new byte[1024]
+        int len
+        while ((len = is.read(buffer)) != -1) {
+            baos.write(buffer, 0, len)
+        }
+        is.close()
+        
+        def classContent = new String(baos.toByteArray(), "ISO-8859-1")
+        
+        // Check for SerializedLambda constant pool entries
+        if (classContent.contains("java/lang/invoke/LambdaMetafactory") ||
+            classContent.contains("SerializedLambda")) {
+            foundSerializedLambdaMetadata = true
+            
+            // If this class uses lambdas, verify it uses the shaded package
+            // The original package should not appear in constant pool references
+            assert !(classContent.contains("org/apache/maven/its/shade/reloc/lambda/" +
+                "Processor") ||
+                classContent.contains("org/apache/maven/its/shade/reloc/lambda/" +
+                "Main") ||
+                classContent.contains("org/apache/maven/its/shade/reloc/lambda/" +
+                "DataHolder")) :
+                "Class ${entry.getName()} contains reference to original " +
+                "package in lambda metadata. All references should use shaded " +
+                "package: org/apache/maven/its/shade/reloc/shaded/lambda/"
+        }
+    }
+}
+
+if (!foundSerializedLambdaMetadata) {
+    println "Warning: No serialized lambda metadata found in classes. " +
+        "This may indicate the test classes were not compiled with lambda usage."
+}
+
+jar.close()
+
+println "Serialized lambda relocation test PASSED!"
+println "All classes properly relocated and no original package references found."

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -941,8 +941,7 @@ public class ShadeMojo extends AbstractMojo {
                     r.getPattern(), r.getShadedPattern(), r.getIncludes(), r.getExcludes(), r.isRawString()));
             if (r.isShadeSerializedLambda()) {
                 relocators.add(new SerializedLambdaRelocator(
-                        r.getPattern(), r.getShadedPattern(), r.getIncludes(), r.getExcludes(), r.isRawString()
-                ));
+                        r.getPattern(), r.getShadedPattern(), r.getIncludes(), r.getExcludes(), r.isRawString()));
             }
         }
 

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -58,6 +58,7 @@ import org.apache.maven.plugins.shade.filter.MinijarFilter;
 import org.apache.maven.plugins.shade.filter.SimpleFilter;
 import org.apache.maven.plugins.shade.pom.PomWriter;
 import org.apache.maven.plugins.shade.relocation.Relocator;
+import org.apache.maven.plugins.shade.relocation.SerializedLambdaRelocator;
 import org.apache.maven.plugins.shade.relocation.SimpleRelocator;
 import org.apache.maven.plugins.shade.resource.ManifestResourceTransformer;
 import org.apache.maven.plugins.shade.resource.ResourceTransformer;
@@ -938,6 +939,11 @@ public class ShadeMojo extends AbstractMojo {
         for (PackageRelocation r : relocations) {
             relocators.add(new SimpleRelocator(
                     r.getPattern(), r.getShadedPattern(), r.getIncludes(), r.getExcludes(), r.isRawString()));
+            if (r.isShadeSerializedLambda()) {
+                relocators.add(new SerializedLambdaRelocator(
+                        r.getPattern(), r.getShadedPattern(), r.getIncludes(), r.getExcludes(), r.isRawString()
+                ));
+            }
         }
 
         return relocators;

--- a/src/main/java/org/apache/maven/plugins/shade/relocation/SerializedLambdaRelocator.java
+++ b/src/main/java/org/apache/maven/plugins/shade/relocation/SerializedLambdaRelocator.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.shade.relocation;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/** @author Kamil Wójcik */
+public class SerializedLambdaRelocator extends SimpleRelocator {
+    private final Pattern serializedLambdaDefinitionPattern = Pattern.compile("\\(([BCDFIJSZ]|\\[+[BCDFIJSZ]|\\[*L[^;]+;)*\\)([BCDFIJSZ]|V|\\[+[BCDFIJSZ]|\\[*L[^;]+;)");
+    private final Pattern clazzInsideFunctionDefintionPattern;
+    private final String shadedPathPattern;
+    private boolean shouldRelocate = true;
+
+
+    public SerializedLambdaRelocator(String pattern, String shadedPattern, List<String> includes, List<String> excludes, boolean rawString) {
+        super(pattern, shadedPattern, includes, excludes, rawString);
+        if (shadedPattern != null && pattern != null) {
+            this.shadedPathPattern = shadedPattern.replace('.', '/');
+            String pathPattern = pattern.replace('.', '/');
+            this.clazzInsideFunctionDefintionPattern = Pattern.compile("(?<=[(;)]L)" + Pattern.quote(pathPattern));
+        } else {
+            this.clazzInsideFunctionDefintionPattern = null;
+            this.shadedPathPattern = null;
+            this.shouldRelocate = false;
+        }
+    }
+
+    @Override
+    public boolean canRelocatePath(String path) {
+        return shouldRelocate && serializedLambdaDefinitionPattern.matcher(path).matches();
+    }
+
+    @Override
+    public boolean canRelocateClass(String clazz) {
+        return false;
+    }
+
+    @Override
+    public String relocatePath(String path) {
+        return !shouldRelocate ? path : clazzInsideFunctionDefintionPattern.matcher(path).replaceAll(shadedPathPattern);
+    }
+
+    @Override
+    public String relocateClass(String input) {
+        return input;
+    }
+
+    @Override
+    public String relocateAllClasses(String input) {
+        return input;
+    }
+
+    @Override
+    public String applyToSourceContent(String sourceContent) {
+        return sourceContent;
+    }
+
+
+}

--- a/src/main/java/org/apache/maven/plugins/shade/relocation/SerializedLambdaRelocator.java
+++ b/src/main/java/org/apache/maven/plugins/shade/relocation/SerializedLambdaRelocator.java
@@ -23,13 +23,14 @@ import java.util.regex.Pattern;
 
 /** @author Kamil Wójcik */
 public class SerializedLambdaRelocator extends SimpleRelocator {
-    private final Pattern serializedLambdaDefinitionPattern = Pattern.compile("\\(([BCDFIJSZ]|\\[+[BCDFIJSZ]|\\[*L[^;]+;)*\\)([BCDFIJSZ]|V|\\[+[BCDFIJSZ]|\\[*L[^;]+;)");
+    private final Pattern serializedLambdaDefinitionPattern =
+            Pattern.compile("\\(([BCDFIJSZ]|\\[+[BCDFIJSZ]|\\[*L[^;]+;)*\\)([BCDFIJSZ]|V|\\[+[BCDFIJSZ]|\\[*L[^;]+;)");
     private final Pattern clazzInsideFunctionDefintionPattern;
     private final String shadedPathPattern;
     private boolean shouldRelocate = true;
 
-
-    public SerializedLambdaRelocator(String pattern, String shadedPattern, List<String> includes, List<String> excludes, boolean rawString) {
+    public SerializedLambdaRelocator(
+            String pattern, String shadedPattern, List<String> includes, List<String> excludes, boolean rawString) {
         super(pattern, shadedPattern, includes, excludes, rawString);
         if (shadedPattern != null && pattern != null) {
             this.shadedPathPattern = shadedPattern.replace('.', '/');
@@ -54,7 +55,9 @@ public class SerializedLambdaRelocator extends SimpleRelocator {
 
     @Override
     public String relocatePath(String path) {
-        return !shouldRelocate ? path : clazzInsideFunctionDefintionPattern.matcher(path).replaceAll(shadedPathPattern);
+        return !shouldRelocate
+                ? path
+                : clazzInsideFunctionDefintionPattern.matcher(path).replaceAll(shadedPathPattern);
     }
 
     @Override
@@ -71,6 +74,4 @@ public class SerializedLambdaRelocator extends SimpleRelocator {
     public String applyToSourceContent(String sourceContent) {
         return sourceContent;
     }
-
-
 }

--- a/src/main/java/org/apache/maven/plugins/shade/relocation/SimpleRelocator.java
+++ b/src/main/java/org/apache/maven/plugins/shade/relocation/SimpleRelocator.java
@@ -217,7 +217,7 @@ public class SimpleRelocator implements Relocator {
         return normalized;
     }
 
-    private boolean isIncluded(String path) {
+    protected boolean isIncluded(String path) {
         if (includes != null && !includes.isEmpty()) {
             for (String include : includes) {
                 if (SelectorUtils.matchPath(include, path, true)) {
@@ -229,7 +229,7 @@ public class SimpleRelocator implements Relocator {
         return true;
     }
 
-    private boolean isExcluded(String path) {
+    protected boolean isExcluded(String path) {
         if (excludes != null && !excludes.isEmpty()) {
             for (String exclude : excludes) {
                 if (SelectorUtils.matchPath(exclude, path, true)) {

--- a/src/test/java/org/apache/maven/plugins/shade/DefaultShaderTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/DefaultShaderTest.java
@@ -124,7 +124,7 @@ public class DefaultShaderTest {
         shader.shade(shadeRequest);
 
         try (JarFile originalJar = new JarFile(plexusJar);
-                JarFile shadedJar = new JarFile(shadedOutput)) {
+             JarFile shadedJar = new JarFile(shadedOutput)) {
             // ASM processes all class files. In doing so, it modifies them, even when not relocating anything.
             // Before MSHADE-391, the processed files were written to the uber JAR, which did no harm, but made it
             // difficult to find out by simple file comparison, if a file was actually relocated or not. Now, Shade
@@ -296,7 +296,7 @@ public class DefaultShaderTest {
         final File dir = TEMPORARY_FOLDER.getRoot();
         // explode src/test/jars/test-artifact-1.0-SNAPSHOT.jar in this temp dir
         try (JarInputStream in =
-                new JarInputStream(Files.newInputStream(Paths.get("src/test/jars/test-artifact-1.0-SNAPSHOT.jar")))) {
+                     new JarInputStream(Files.newInputStream(Paths.get("src/test/jars/test-artifact-1.0-SNAPSHOT.jar")))) {
             JarEntry nextJarEntry;
             while ((nextJarEntry = in.getNextJarEntry()) != null) {
                 if (nextJarEntry.isDirectory()) {
@@ -504,7 +504,7 @@ public class DefaultShaderTest {
         JarEntry entry = shadedJarFile.getJarEntry(serviceEntryName);
 
         List<String> lines = new BufferedReader(
-                        new InputStreamReader(shadedJarFile.getInputStream(entry), StandardCharsets.UTF_8))
+                new InputStreamReader(shadedJarFile.getInputStream(entry), StandardCharsets.UTF_8))
                 .lines()
                 .collect(Collectors.toList());
 
@@ -622,9 +622,9 @@ public class DefaultShaderTest {
     private boolean areEqual(final JarFile jar1, final JarFile jar2, final String entry1, String entry2)
             throws IOException {
         try (InputStream s1 = jar1.getInputStream(
-                        requireNonNull(jar1.getJarEntry(entry1), entry1 + " in " + jar1.getName()));
-                InputStream s2 = jar2.getInputStream(
-                        requireNonNull(jar2.getJarEntry(entry2), entry2 + " in " + jar2.getName()))) {
+                requireNonNull(jar1.getJarEntry(entry1), entry1 + " in " + jar1.getName()));
+             InputStream s2 = jar2.getInputStream(
+                     requireNonNull(jar2.getJarEntry(entry2), entry2 + " in " + jar2.getName()))) {
             return Arrays.equals(IOUtil.toByteArray(s1), IOUtil.toByteArray(s2));
         }
     }

--- a/src/test/java/org/apache/maven/plugins/shade/DefaultShaderTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/DefaultShaderTest.java
@@ -124,7 +124,7 @@ public class DefaultShaderTest {
         shader.shade(shadeRequest);
 
         try (JarFile originalJar = new JarFile(plexusJar);
-             JarFile shadedJar = new JarFile(shadedOutput)) {
+                JarFile shadedJar = new JarFile(shadedOutput)) {
             // ASM processes all class files. In doing so, it modifies them, even when not relocating anything.
             // Before MSHADE-391, the processed files were written to the uber JAR, which did no harm, but made it
             // difficult to find out by simple file comparison, if a file was actually relocated or not. Now, Shade
@@ -296,7 +296,7 @@ public class DefaultShaderTest {
         final File dir = TEMPORARY_FOLDER.getRoot();
         // explode src/test/jars/test-artifact-1.0-SNAPSHOT.jar in this temp dir
         try (JarInputStream in =
-                     new JarInputStream(Files.newInputStream(Paths.get("src/test/jars/test-artifact-1.0-SNAPSHOT.jar")))) {
+                new JarInputStream(Files.newInputStream(Paths.get("src/test/jars/test-artifact-1.0-SNAPSHOT.jar")))) {
             JarEntry nextJarEntry;
             while ((nextJarEntry = in.getNextJarEntry()) != null) {
                 if (nextJarEntry.isDirectory()) {
@@ -504,7 +504,7 @@ public class DefaultShaderTest {
         JarEntry entry = shadedJarFile.getJarEntry(serviceEntryName);
 
         List<String> lines = new BufferedReader(
-                new InputStreamReader(shadedJarFile.getInputStream(entry), StandardCharsets.UTF_8))
+                        new InputStreamReader(shadedJarFile.getInputStream(entry), StandardCharsets.UTF_8))
                 .lines()
                 .collect(Collectors.toList());
 
@@ -622,9 +622,9 @@ public class DefaultShaderTest {
     private boolean areEqual(final JarFile jar1, final JarFile jar2, final String entry1, String entry2)
             throws IOException {
         try (InputStream s1 = jar1.getInputStream(
-                requireNonNull(jar1.getJarEntry(entry1), entry1 + " in " + jar1.getName()));
-             InputStream s2 = jar2.getInputStream(
-                     requireNonNull(jar2.getJarEntry(entry2), entry2 + " in " + jar2.getName()))) {
+                        requireNonNull(jar1.getJarEntry(entry1), entry1 + " in " + jar1.getName()));
+                InputStream s2 = jar2.getInputStream(
+                        requireNonNull(jar2.getJarEntry(entry2), entry2 + " in " + jar2.getName()))) {
             return Arrays.equals(IOUtil.toByteArray(s1), IOUtil.toByteArray(s2));
         }
     }


### PR DESCRIPTION
[MSHADE-260] shading does not rewrite Lambda deserializers

Added additional relocator that is able to detect java's function definitions, inside raw strings. This is enabled only by adding tag in plugin configuration, e.g.
```xml
<relocation>
  <pattern>com.example</pattern>
  <shadedPattern>com.shaded.example</shadedPattern>
  <shadeSerializedLambda/>
</relocation>
```
New relocator uses regex to find function definitions inside raw strings, upon detecting such definition it proceeds to replace all references to original package.

Added new integration test to test if new behavior is really replacing original pattern in serialized lambdas.

This is my first PR so I didn't want to integrate into original code, my idea was to add this under feature flag so if there are problems with it (performance, regression, whatever) end user does not have to opt in.


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHADE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHADE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHADE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

