### PR TITLE
Fix integration tests for Maven 4.0.0-rc-5 builds

### DIFF
--- a/src/it/projects/MSHADE-105/pom.xml
+++ b/src/it/projects/MSHADE-105/pom.xml
@@ -29,4 +29,20 @@ under the License.
     <module>bundle</module>
   </modules>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>@version.maven-resources-plugin@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>@version.maven-jar-plugin@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/src/it/projects/MSHADE-284_shadeTestJar/pom.xml
+++ b/src/it/projects/MSHADE-284_shadeTestJar/pom.xml
@@ -64,6 +64,7 @@ under the License.
         <plugins>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>@version.maven-jar-plugin@</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/it/projects/MSHADE-285_createTestSourcesJar/pom.xml
+++ b/src/it/projects/MSHADE-285_createTestSourcesJar/pom.xml
@@ -64,6 +64,7 @@ under the License.
         <plugins>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>@version.maven-source-plugin@</version>
                 <executions>
                     <execution>
                         <goals>
@@ -74,6 +75,7 @@ under the License.
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>@version.maven-jar-plugin@</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/it/projects/MSHADE-340_shadedTestJarArtifactAttached/pom.xml
+++ b/src/it/projects/MSHADE-340_shadedTestJarArtifactAttached/pom.xml
@@ -79,6 +79,7 @@ under the License.
         <plugins>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>@version.maven-source-plugin@</version>
                 <executions>
                     <execution>
                         <id>default-source</id>
@@ -91,6 +92,7 @@ under the License.
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>@version.maven-jar-plugin@</version>
                 <executions>
                     <execution>
                         <id>default-jar</id>

--- a/src/it/projects/MSHADE-467_parallel-dependency-reduced-pom/pom.xml
+++ b/src/it/projects/MSHADE-467_parallel-dependency-reduced-pom/pom.xml
@@ -157,6 +157,11 @@ under the License.
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>@version.maven-jar-plugin@</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>@project.version@</version>
                     <executions>

--- a/src/it/projects/mshade-123/pom.xml
+++ b/src/it/projects/mshade-123/pom.xml
@@ -29,12 +29,6 @@ under the License.
   <version>0.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
## Summary

Pin plugin versions in six failing integration tests so the suite builds clean under Maven 4.0.0-rc-5.

Companion to #810 (which flips the shared workflow's `maven4-enabled: true` flag); per @hboutemy's review feedback, this PR no longer touches the workflow — #810 will rebase on top of this once these IT fixes land.

## Root cause

Under Maven 4.0.0-rc-5, when an IT POM does not pin a plugin version, Maven 4 picks the `4.0.0-beta-1` of `maven-jar-plugin`, `maven-resources-plugin`, `maven-source-plugin` as the default. Those betas were built against an earlier Maven 4 rc API which has since changed; they throw `NoSuchMethodError` at runtime on:

- `Project.getPomArtifact()` (for `maven-jar-plugin:4.0.0-beta-1`)
- `ProjectManager.getResources(...)` (for `maven-resources-plugin:4.0.0-beta-1`)
- `PluginParameterExpressionEvaluator.<init>(...)` (for `maven-enforcer-plugin:1.0`, inherited from `oss-parent:7`)

## Changes

- `src/it/projects/MSHADE-105/pom.xml` — add `<pluginManagement>` pinning resources + jar plugins
- `src/it/projects/MSHADE-284_shadeTestJar/pom.xml` — pin `maven-jar-plugin`
- `src/it/projects/MSHADE-285_createTestSourcesJar/pom.xml` — pin `maven-source-plugin` and `maven-jar-plugin` via the parent-pom filter properties (`@version.maven-source-plugin@`, `@version.maven-jar-plugin@`)
- `src/it/projects/MSHADE-340_shadedTestJarArtifactAttached/pom.xml` — same pattern
- `src/it/projects/MSHADE-467_parallel-dependency-reduced-pom/pom.xml` — add `maven-jar-plugin` to `<pluginManagement>`
- `src/it/projects/mshade-123/pom.xml` — drop `<parent>org.sonatype.oss:oss-parent:7</parent>` (was pulling in `maven-enforcer-plugin:1.0`)

## Test plan

Verified locally with sdkman-installed `Apache Maven 4.0.0-rc-5 (fb3ecaef…)` on JDK 17.0.18 Temurin / macOS aarch64, isolated `-Dmaven.repo.local`:

```
Build Summary:
  Passed: 83, Failed: 0, Errors: 0, Skipped: 1
```

Versus the pre-fix baseline of `Passed: 76, Failed: 7, Errors: 0, Skipped: 1`.

## After merge

- [ ] Update the [Maven 4.0.0 GA checklist](https://cwiki.apache.org/confluence/display/MAVEN/Maven+4.0.0+GA+checklist) `maven-shade-plugin` row: mark `works with 4.0.0-rc-5: ✓`, set status to Done, shorten the comment to "Fixed in #816".
- [ ] #810 rebases on top of this to flip `maven4-enabled: true` (per @hboutemy review).
