### PR TITLE
Fix documentation issues in site docs

### DIFF
--- a/src/site/apt/examples/class-relocation.apt.vm
+++ b/src/site/apt/examples/class-relocation.apt.vm
@@ -81,10 +81,10 @@ Relocating Classes
       <pattern>org.codehaus.plexus.util</pattern>
       <shadedPattern>org.shaded.plexus.util</shadedPattern>
       <includes>
-        <include>org.codehaud.plexus.util.io.*</include>
+        <include>org.codehaus.plexus.util.io.*</include>
       </includes>
       <excludes>
-        <exclude>org.codehaud.plexus.util.io.*</exclude>
+        <exclude>org.codehaus.plexus.util.io.*</exclude>
       </excludes>
     </relocation>
   ...

--- a/src/site/apt/examples/includes-excludes.apt.vm
+++ b/src/site/apt/examples/includes-excludes.apt.vm
@@ -154,7 +154,7 @@ Selecting Contents for Uber JAR
 
   As of version 1.6, minimizeJar will respect classes that were specifically marked for inclusion in a filter.
   Note that specifying an include filter for classes in an artifact implicitly excludes all non-specified
-  classes in that artifact. <<<\<excludeDefaults\>false\<\\excludeDefaults\>>>> will override this behavior so that all
+  classes in that artifact. <<<\<excludeDefaults\>false\<\/excludeDefaults\>>>> will override this behavior so that all
   non-specified classes still will be included though.
 
 +-----

--- a/src/site/apt/examples/resource-transformers.apt.vm
+++ b/src/site/apt/examples/resource-transformers.apt.vm
@@ -25,7 +25,7 @@
 
 Resource Transformers
 
-  Aggregating classes/resources from several artifacts into one uber JAR is straight forward as long as there is no
+  Aggregating classes/resources from several artifacts into one uber JAR is straightforward as long as there is no
   overlap. Otherwise, some kind of logic to merge resources from several JARs is required. This is where resource
   transformers kick in.
 
@@ -47,7 +47,7 @@ Resource Transformers
 *-----------------------------------------+------------------------------------------+
 | {{ManifestResourceTransformer}}         | Sets entries in the <<<MANIFEST>>>       |
 *-----------------------------------------+------------------------------------------+
-| {{PluginXmlResourceTransformer}}        | Aggregates Mavens <<<plugin.xml>>>       |
+| {{PluginXmlResourceTransformer}}        | Aggregates Maven's <<<plugin.xml>>>      |
 *-----------------------------------------+------------------------------------------+
 | {{ResourceBundleAppendingTransformer}}  | Merges ResourceBundles                  | 
 *-----------------------------------------+------------------------------------------+
@@ -105,8 +105,8 @@ Transformers in <<<org.apache.maven.plugins.shade.resource.properties>>> (availa
 
 * Relocate classes of the Maven Plugin Descriptor with the {PluginXmlResourceTransformer}
 
-  With {{{http://maven.apache.org/plugin-tools/index.html}Plugin Tools 3.0}} annotations have been introduced. Now references 
-  to classes are no longer classnames as String, but the actual Class reference. When you wanted to relocate classes, you had to
+  With {{{https://maven.apache.org/plugin-tools/index.html}Plugin Tools 3.0}}, annotations were introduced. References 
+  to classes are now real Class references rather than class names as strings. When you wanted to relocate classes, you had to
   maintain the <<<META-INF/maven/plugin.xml>>> by hand, but now this can be done with the <<<PluginXmlResourceTransformer>>>  
 
 +-----
@@ -176,7 +176,7 @@ Transformers in <<<org.apache.maven.plugins.shade.resource.properties>>> (availa
 * Merging Content of Specific Files with {AppendingTransformer}, XmlAppendingTransformer and ResourceBundleAppendingTransformer
 
   Some jars contain additional resources (such as properties files) that have the same file name. To avoid overwriting, you can
-  opt to merge them by appending their content into one file. One good example for this is when aggregating both the spring-context 
+  merge them by appending their content. One good example for this is when aggregating both the spring-context 
   and plexus-spring jars. Both of them have the <<<META-INF/spring.handlers>>> file which is used by Spring to handle XML schema 
   namespaces. You can merge the contents of all the files with that specific name using the <<<AppendingTransformer>>> as shown below:
   
@@ -525,7 +525,7 @@ Transformers in <<<org.apache.maven.plugins.shade.resource.properties>>> (availa
 
   The Apache Groovy language provides extension modules located at
   <<<META-INF/services/org.codehaus.groovy.runtime.ExtensionModule>>>, these modules use the property file format.
-  <<<GroovyResourceTransformer>>> automates the assembly of Groovy extension modules <<<NOTICE>>>.
+  <<<GroovyResourceTransformer>>> automates the assembly of Groovy extension module descriptors.
 
   For example, to simply merge the extension modules of several jars:
 

--- a/src/site/apt/examples/resource-transformers.apt.vm
+++ b/src/site/apt/examples/resource-transformers.apt.vm
@@ -100,13 +100,13 @@ Transformers in <<<org.apache.maven.plugins.shade.resource.properties>>> (availa
 </project>
 +-----
 
-  Since plugin version 1.3, this resource transformer will also update the descriptor to account for relocation of
+  Since plugin version 1.3, this resource transformer also updates the descriptor to account for relocation of
   component interfaces/implementations (if any).
 
 * Relocate classes of the Maven Plugin Descriptor with the {PluginXmlResourceTransformer}
 
   With {{{https://maven.apache.org/plugin-tools/index.html}Plugin Tools 3.0}}, annotations were introduced. References 
-  to classes are now real Class references rather than class names as strings. When you wanted to relocate classes, you had to
+  to classes are now references to java.lang.Class objects rather than strings containing class names. When you wanted to relocate classes, you had to
   maintain the <<<META-INF/maven/plugin.xml>>> by hand, but now this can be done with the <<<PluginXmlResourceTransformer>>>  
 
 +-----

--- a/src/site/apt/examples/resource-transformers.apt.vm
+++ b/src/site/apt/examples/resource-transformers.apt.vm
@@ -176,7 +176,7 @@ Transformers in <<<org.apache.maven.plugins.shade.resource.properties>>> (availa
 * Merging Content of Specific Files with {AppendingTransformer}, XmlAppendingTransformer and ResourceBundleAppendingTransformer
 
   Some jars contain additional resources (such as properties files) that have the same file name. To avoid overwriting, you can
-  merge them by appending their content. One good example for this is when aggregating both the spring-context 
+  merge them by appending their content. One good example of this is aggregating both the spring-context 
   and plexus-spring jars. Both of them have the <<<META-INF/spring.handlers>>> file which is used by Spring to handle XML schema 
   namespaces. You can merge the contents of all the files with that specific name using the <<<AppendingTransformer>>> as shown below:
   

--- a/src/site/apt/examples/use-shader-other-impl.apt.vm
+++ b/src/site/apt/examples/use-shader-other-impl.apt.vm
@@ -25,7 +25,7 @@
 
 Using your own Shader implementation
 
-  By default, the plugin provides a DefaultShader implementation but with version 1.6 you can use your own implementation.
+  By default, the plugin provides a DefaultShader implementation. You can, however, use your own implementation.
 
   Create a standard Maven project with your implementation.
 

--- a/src/site/apt/examples/use-shader-other-impl.apt.vm
+++ b/src/site/apt/examples/use-shader-other-impl.apt.vm
@@ -1,5 +1,5 @@
  ------
- Using an other Shader Implementation
+ Using another Shader Implementation
  ------
  Olivier Lamy
  ------
@@ -25,31 +25,34 @@
 
 Using your own Shader implementation
 
-  By default, the plugin provide a DefaultShader implementation but with version 1.6 you can use your own implementation.
+  By default, the plugin provides a DefaultShader implementation but with version 1.6 you can use your own implementation.
 
   Create a standard Maven project with your implementation.
 
+  Dependency for Plexus annotations:
+
 +-----
-
-Dependency to Plexus annotations
-
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-component-annotations</artifactId>
       <version>1.5.5</version>
     </dependency>
++-----
 
-Create your Shader
+  Create your Shader:
 
++-----
 @Component( role = Shader.class, hint = "mock" )
 public class MockShader
     implements Shader
 {
   // implement the interface here
 }
++-----
 
-// Use the plexus component metadata plugin in your job to generate Plexus metadata
+  Use the Plexus Component Metadata plugin in your build to generate Plexus metadata:
 
++-----
       <plugin>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-component-metadata</artifactId>

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -25,8 +25,8 @@
 
 ${project.name}
 
- This plugin provides the capability to package the artifact in an uber-jar, including its dependencies,
- and to shade -- i.e. relocate -- the packages of some of the dependencies.
+ This plugin can package the artifact in an uber-jar, including its dependencies,
+ and shade — that is, relocate — the packages of some of the dependencies.
 
 * Goals Overview
 
@@ -42,12 +42,12 @@ ${project.name}
   General instructions on how to use the Shade Plugin can be found on the {{{./usage.html}usage page}}. Some more
   specific use cases are described in the examples given below.
 
-  In case you still have questions regarding the plugin's usage, please feel
+  If you have questions regarding the plugin's usage, please feel
   free to contact the {{{./mailing-lists.html}user mailing list}}. The posts to the mailing list are archived and could
   already contain the answer to your question as part of an older thread. Hence, it is also worth browsing/searching
   the {{{./mailing-lists.html}mail archive}}.
 
-  If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our
+  If you think the plugin is missing a feature or has a defect, you can file a feature request or bug report in our
   {{{./issue-management.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your
   concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason,
   entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
@@ -58,8 +58,8 @@ ${project.name}
 
 * Examples
 
-  To provide you with better understanding on some usages of the Shade Plugin,
-  you can take a look into the following examples:
+  To help you understand some usages of the Shade Plugin,
+  look into the following examples:
 
   * {{{./examples/includes-excludes.html}Selecting Contents for Uber JAR}}
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -25,15 +25,17 @@
 
 ${project.name}
 
- This plugin provides the capability to package the artifact in an uber-jar, including its dependencies and
- to <shade> - i.e. rename - the packages of some of the dependencies.
+ This plugin provides the capability to package the artifact in an uber-jar, including its dependencies,
+ and to shade -- i.e. relocate -- the packages of some of the dependencies.
 
 * Goals Overview
 
-  The Shade Plugin has a single goal:
+  The Shade Plugin has 2 goals:
 
   * {{{./shade-mojo.html}shade:shade}} is bound to the <<<package>>> phase and
   is used to create a shaded jar.
+
+  * {{{./help-mojo.html}shade:help}} displays help information about the plugin.
 
 * Usage
 
@@ -43,7 +45,7 @@ ${project.name}
   In case you still have questions regarding the plugin's usage, please feel
   free to contact the {{{./mailing-lists.html}user mailing list}}. The posts to the mailing list are archived and could
   already contain the answer to your question as part of an older thread. Hence, it is also worth browsing/searching
-  the {{{./mail-lists.html}mail archive}}.
+  the {{{./mailing-lists.html}mail archive}}.
 
   If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our
   {{{./issue-management.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your
@@ -51,7 +53,7 @@ ${project.name}
   entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
   Of course, patches are welcome, too. Contributors can check out the project from our
   {{{./scm.html}source repository}} and will find supplementary information in the
-  {{{http://maven.apache.org/guides/development/guide-helping.html}guide to helping with Maven}}.
+  {{{https://maven.apache.org/guides/development/guide-helping.html}guide to helping with Maven}}.
 
 
 * Examples

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -84,6 +84,12 @@ mvn package
 *-----------------------------------------+--------------------------------------+
 | XmlAppendingTransformer                 | Adds XML content to an XML resource  | 
 *-----------------------------------------+--------------------------------------+
-Transformers in <<<org.apache.maven.plugins.shade.resource>>>
+| PropertiesTransformer                   | Merges properties files using an ordinal to resolve conflicts |
+*-----------------------------------------+--------------------------------------+
+| OpenWebBeansPropertiesTransformer       | Merges Apache OpenWebBeans configuration files |
+*-----------------------------------------+--------------------------------------+
+| MicroprofileConfigTransformer           | Merges Microprofile Config properties based on an ordinal |
+*-----------------------------------------+--------------------------------------+
+Transformers in <<<org.apache.maven.plugins.shade.resource>>> and <<<org.apache.maven.plugins.shade.resource.properties>>>
 
   For more information, see {{{./examples/resource-transformers.html}samples}}.

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -28,14 +28,14 @@ under the License.
      <question>Why Does My Second Shade Include The Results Of The First Execution?</question>
      <answer>
        <p>
-       By default, shade replaces with original jar with the result of shading.
+       By default, shade replaces the original jar with the result of shading.
        So, when a <code>pom.xml</code> includes two shades, 
        the second shade execution will (by default) start from the result of the 
        first shade execution.
        </p><p>
        If you're looking for two independent shades then read 
        in <a href='shade-mojo.html'>shade:shade</a> about
-       ways choose a different name for your first shade.
+       ways to choose a different name for your first shade.
        </p>
      </answer>
    </faq>

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -20,7 +20,7 @@ under the License.
 
 <faqs xmlns="http://maven.apache.org/FML/1.0.1"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/FML/1.0.1 http://maven.apache.org/xsd/fml-1.0.1.xsd"
+  xsi:schemaLocation="http://maven.apache.org/FML/1.0.1 https://maven.apache.org/xsd/fml-1.0.1.xsd"
   id="FAQ" 
   title="Frequently Asked Questions">
  <part id="general">
@@ -30,10 +30,10 @@ under the License.
        <p>
        By default, shade replaces the original jar with the result of shading.
        So, when a <code>pom.xml</code> includes two shades, 
-       the second shade execution will (by default) start from the result of the 
+       the second shade execution by default starts from the result of the 
        first shade execution.
        </p><p>
-       If you're looking for two independent shades then read 
+       If you're looking for two independent shades, then read 
        in <a href='shade-mojo.html'>shade:shade</a> about
        ways to choose a different name for your first shade.
        </p>


### PR DESCRIPTION
Fixes multiple issues across the site documentation:

### index.apt.vm
- **Broken link:** `mail-lists.html` → `mailing-lists.html` (the correct generated page name)
- **Insecure link:** `http://` → `https://` for maven.apache.org guide link
- **Factual error:** 'a single goal' → '2 goals' — the plugin also has a `shade:help` goal (listed in site.xml)
- **Awkward phrasing:** Reworded the introductory sentence for clarity

### usage.apt.vm
- **Omission:** Added the 3 missing transformers from `org.apache.maven.plugins.shade.resource.properties` to the resource transformers table

### faq.fml
- **Grammar:** 'replaces with original' → 'replaces the original'
- **Missing word:** 'ways choose' → 'ways to choose'

### includes-excludes.apt.vm
- **Incorrect APT escaping:** Fixed `\` → `\/` so the `<excludeDefaults>false</excludeDefaults>` element renders correctly

### class-relocation.apt.vm
- **Typo:** `org.codehaud` → `org.codehaus` (two occurrences in the example POM)

### resource-transformers.apt.vm
- **Typo:** 'straight forward' → 'straightforward'
- **Possessive:** 'Mavens' → 'Maven's'
- **Copy-paste error:** Removed spurious 'NOTICE' from GroovyResourceTransformer description
- **Insecure link:** `http://` → `https://` for plugin-tools link
- **Unclear phrasing:** Reworded the sentence about Class references
- **Redundant phrasing:** Simplified 'opt to merge them by appending their content into one file'

### use-shader-other-impl.apt.vm
- **Subject-verb agreement:** 'plugin provide' → 'plugin provides'
- **Formatting:** Extracted prose from inside the `+-----+` code block so it renders as text, not code
- **Title:** 'an other' → 'another'
- **Preposition:** 'Dependency to' → 'Dependency for'
- **Word choice:** 'in your job' → 'in your build'