### PR TITLE
[MSHADE-434] Restore project.getFile() after dependency-reduced POM creation

### DIFF
--- a/src/it/projects/MSHADE-434_ratSideEffect/pom.xml
+++ b/src/it/projects/MSHADE-434_ratSideEffect/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade</groupId>
+  <artifactId>mshade-434</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <name>MSHADE-434</name>
+  <description>
+    Test that project.getFile() is restored to the original pom.xml after shading,
+    preventing side effects on subsequent plugins (e.g., RAT, checkstyle).
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.shade.fac</groupId>
+      <artifactId>a</artifactId>
+      <version>0.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>check-project-file</id>
+            <phase>package</phase>
+            <goals>
+              <goal>evaluate</goal>
+            </goals>
+            <configuration>
+              <expression>project.file</expression>
+              <forceStdout>true</forceStdout>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-434_ratSideEffect/verify.groovy
+++ b/src/it/projects/MSHADE-434_ratSideEffect/verify.groovy
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Verify the dependency-reduced POM was created in the expected location
+File drpFile = new File(basedir, "target/dependency-reduced-pom.xml")
+assert drpFile.isFile() : "DRP should exist at " + drpFile
+
+// Verify the shaded JAR was created
+File shadedJar = new File(basedir, "target/mshade-434-1.0.jar")
+assert shadedJar.isFile() : "Shaded JAR should exist at " + shadedJar
+
+// Verify that project.getFile() was restored to the original pom.xml after shading
+// by checking the build log for the help:evaluate output
+File buildLog = new File(basedir, "../build.log")
+if (!buildLog.isFile()) {
+    buildLog = new File(basedir, "build.log")
+}
+assert buildLog.isFile() : "build.log should exist"
+
+def lines = buildLog.readLines()
+// help:evaluate with forceStdout prints the expression value on its own line
+// Look for a bare absolute path that ends with "/pom.xml" (not "dependency-reduced-pom.xml")
+def projectFileLine = lines.find { it =~ /^\// && it.endsWith("/pom.xml") }
+assert projectFileLine != null : "project.file value not found in build log (expected a path ending with /pom.xml)"
+assert projectFileLine.endsWith("/pom.xml") : "project.file should be pom.xml, but was: " + projectFileLine

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -544,6 +544,7 @@ public class ShadeMojo extends AbstractMojo {
             List<ResourceTransformer> resourceTransformers = getResourceTransformers();
 
             if (createDependencyReducedPom) {
+                File originalProjectFile = project.getFile();
                 createDependencyReducedPom(artifactIds);
 
                 if (useDependencyReducedPomInJar) {
@@ -551,6 +552,7 @@ public class ShadeMojo extends AbstractMojo {
                     resourceTransformers = new ArrayList<>(resourceTransformers);
                     resourceTransformers.addAll(createPomReplaceTransformers(project, dependencyReducedPomLocation));
                 }
+                project.setFile(originalProjectFile);
             }
 
             ShadeRequest shadeRequest =


### PR DESCRIPTION
## Problem

Calling `project.setFile(dependencyReducedPomLocation)` in `ShadeMojo` changes the project file reference for all subsequent plugins in the build. This causes plugins like `apache-rat-plugin` and `maven-checkstyle-plugin` to resolve relative paths against the wrong directory, breaking their behavior. 

Specifically, when `dependencyReducedPomLocation` is set to a directory other than `${basedir}` (e.g., `target/`), `project.getFile()` returns the DRP path, and plugins relying on `getFile().getParentFile()` for basedir resolution will resolve paths incorrectly.

This was introduced/changed by MSHADE-321 (commit 6ea8543) which moved the `createDependencyReducedPom()` call outside of the inner artifact-processing block.

## Fix

Save `project.getFile()` before calling `createDependencyReducedPom()` and restore it afterward in `ShadeMojo.execute()`. This ensures `project.getFile()` continues to point to the original `pom.xml` after the shade plugin finishes, preventing side effects on subsequent plugins.

## Integration Test

`MSHADE-434_ratSideEffect`: Configures shade with `dependencyReducedPomLocation` in `target/`, then verifies via `maven-help-plugin:evaluate` that `${project.file}` still points to the original `pom.xml` after shading.

- Without fix: test fails (project.file is `dependency-reduced-pom.xml`)
- With fix: test passes (project.file is `pom.xml`)

All 72 unit tests pass.

Fixes #453