### PR TITLE
[MSHADE-419] Restore project.getFile() after dependency-reduced POM creation when shadedArtifactAttached=true

### DIFF
--- a/src/it/projects/MSHADE-419_attachedDepPom/pom.xml
+++ b/src/it/projects/MSHADE-419_attachedDepPom/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade</groupId>
+  <artifactId>mshade-419</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <name>MSHADE-419</name>
+  <description>
+    Test that project.getFile() still points to the original pom.xml
+    when shadedArtifactAttached=true, preventing the dependency-reduced
+    POM from being used for install/deploy.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.shade.fac</groupId>
+      <artifactId>a</artifactId>
+      <version>0.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>shaded</shadedClassifierName>
+              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>check-project-file</id>
+            <phase>package</phase>
+            <goals>
+              <goal>evaluate</goal>
+            </goals>
+            <configuration>
+              <expression>project.file</expression>
+              <forceStdout>true</forceStdout>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-419_attachedDepPom/verify.groovy
+++ b/src/it/projects/MSHADE-419_attachedDepPom/verify.groovy
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Verify the dependency-reduced POM was created in the expected location
+File drpFile = new File(basedir, "target/dependency-reduced-pom.xml")
+assert drpFile.isFile() : "DRP should exist at " + drpFile
+
+// Verify the original (non-shaded) artifact exists
+File originalJar = new File(basedir, "target/mshade-419-1.0.jar")
+assert originalJar.isFile() : "Original artifact should exist at " + originalJar
+
+// Verify the shaded (attached) artifact exists with the classifier
+File shadedJar = new File(basedir, "target/mshade-419-1.0-shaded.jar")
+assert shadedJar.isFile() : "Shaded artifact should exist at " + shadedJar
+
+// Verify that project.getFile() still points to the original pom.xml after shading,
+// NOT to the dependency-reduced-pom.xml. This is critical because when
+// shadedArtifactAttached=true, the original artifact is the main artifact and
+// its POM comes from project.getFile(). If project.getFile() points to the DRP,
+// the deployed POM will lose all compile dependencies.
+File buildLog = new File(basedir, "../build.log")
+if (!buildLog.isFile()) {
+    buildLog = new File(basedir, "build.log")
+}
+assert buildLog.isFile() : "build.log should exist"
+
+def lines = buildLog.readLines()
+def projectFileLine = lines.find { it =~ /^\// && it.endsWith("/pom.xml") }
+assert projectFileLine != null : "project.file value not found in build log (expected a path ending with /pom.xml)"
+assert projectFileLine.endsWith("/pom.xml") : "project.file should be pom.xml, but was: " + projectFileLine

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -544,6 +544,7 @@ public class ShadeMojo extends AbstractMojo {
             List<ResourceTransformer> resourceTransformers = getResourceTransformers();
 
             if (createDependencyReducedPom) {
+                File originalProjectFile = project.getFile();
                 createDependencyReducedPom(artifactIds);
 
                 if (useDependencyReducedPomInJar) {
@@ -551,6 +552,7 @@ public class ShadeMojo extends AbstractMojo {
                     resourceTransformers = new ArrayList<>(resourceTransformers);
                     resourceTransformers.addAll(createPomReplaceTransformers(project, dependencyReducedPomLocation));
                 }
+                project.setFile(originalProjectFile);
             }
 
             ShadeRequest shadeRequest =


### PR DESCRIPTION
## Problem

When `shadedArtifactAttached=true`, the original (non-shaded) artifact remains the main artifact of the project. The POM used for this main artifact comes from `project.getFile()`. After `createDependencyReducedPom()` calls `project.setFile(dependencyReducedPomLocation)`, `project.getFile()` points to the dependency-reduced POM instead of the original `pom.xml`.

This causes `maven-install-plugin` and `maven-deploy-plugin` to use the dependency-reduced POM (which has compile dependencies removed) as the project's POM. Downstream projects depending on the library lose transitive compile dependencies.

Introduced/changed by MSHADE-321 (commit 6ea8543). The issue manifests specifically when:
- `shadedArtifactAttached=true` (so the original artifact is retained)
- `createDependencyReducedPom=true` (default)
- Compile dependencies exist that get shaded and removed from the DRP

## Fix

Save `project.getFile()` before calling `createDependencyReducedPom()` and restore it afterward in `ShadeMojo.execute()`. This ensures `project.getFile()` continues to point to the original `pom.xml`, so install/deploy use the correct POM with all compile dependencies.

## Integration Test

`MSHADE-419_attachedDepPom`: Configures shade with `shadedArtifactAttached=true` and `dependencyReducedPomLocation` in `target/`, then verifies via `maven-help-plugin:evaluate` that `${project.file}` still points to the original `pom.xml` after shading.

- Without fix: test fails (project.file is `dependency-reduced-pom.xml`)
- With fix: test passes (project.file is `pom.xml`)

All 72 unit tests pass.

Fixes #711