### PR TITLE
Use project name in generated Apache NOTICE

### DIFF
--- a/src/it/projects/apache-notice-project-name/pom.xml
+++ b/src/it/projects/apache-notice-project-name/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade</groupId>
+  <artifactId>apache-notice-project-name</artifactId>
+  <version>1.0</version>
+  <name>Maven Shade Notice Reproducer</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/apache-notice-project-name/src/main/resources/META-INF/NOTICE
+++ b/src/it/projects/apache-notice-project-name/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,1 @@
+Dependency notice

--- a/src/it/projects/apache-notice-project-name/verify.groovy
+++ b/src/it/projects/apache-notice-project-name/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.jar.JarFile
+
+def shadedJar = new JarFile(new File(basedir, "target/apache-notice-project-name-1.0.jar"))
+try {
+    def notice = shadedJar.getInputStream(shadedJar.getJarEntry("META-INF/NOTICE")).getText("UTF-8")
+    assert notice.contains("Version 2.0, in this case for Maven Shade Notice Reproducer")
+} finally {
+    shadedJar.close()
+}

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -60,6 +60,7 @@ import org.apache.maven.plugins.shade.pom.PomWriter;
 import org.apache.maven.plugins.shade.relocation.Relocator;
 import org.apache.maven.plugins.shade.relocation.SerializedLambdaRelocator;
 import org.apache.maven.plugins.shade.relocation.SimpleRelocator;
+import org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer;
 import org.apache.maven.plugins.shade.resource.ManifestResourceTransformer;
 import org.apache.maven.plugins.shade.resource.ResourceTransformer;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
@@ -970,6 +971,9 @@ public class ShadeMojo extends AbstractMojo {
             if (transformer == null) {
                 throw new MojoExecutionException(
                         "Failed to create shaded artifact: parameter transformers contains null (double-check XML attribute)");
+            }
+            if (transformer instanceof ApacheNoticeResourceTransformer) {
+                ((ApacheNoticeResourceTransformer) transformer).setProjectNameIfUnset(project.getName());
             }
         }
         return Arrays.asList(transformers);

--- a/src/main/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformer.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformer.java
@@ -79,6 +79,19 @@ public class ApacheNoticeResourceTransformer extends AbstractCompatibilityTransf
 
     private static final String NOTICE_MD_PATH = "META-INF/NOTICE.md";
 
+    /**
+     * Uses the Maven project name when no project name was configured explicitly.
+     *
+     * @param projectName the Maven project name
+     */
+    public void setProjectNameIfUnset(String projectName) {
+        if (this.projectName.isEmpty()
+                && projectName != null
+                && !projectName.trim().isEmpty()) {
+            this.projectName = projectName;
+        }
+    }
+
     @Override
     public boolean canTransformResource(String resource) {
         return NOTICE_PATH.equalsIgnoreCase(resource)

--- a/src/site/markdown/examples/resource-transformers.md.vm
+++ b/src/site/markdown/examples/resource-transformers.md.vm
@@ -442,6 +442,9 @@ For example, the following prevents the license from a `commons-collections` dep
 
 Some licenses (including the [ Apache License, Version 2](https://www.apache.org/licenses/LICENSE-2.0.html)) require that notices are preserved by downstream distributors. `ApacheNoticeResourceTransformer` automates the assembly of an appropriate `NOTICE`.
 
+The generated notice uses the Maven project name by default. This can be overridden with the
+`projectName` transformer parameter.
+
 For example, to simply merge in dependent notices:
 
 ```xml

--- a/src/test/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformerTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/resource/ApacheNoticeResourceTransformerTest.java
@@ -28,6 +28,7 @@ import org.apache.maven.plugins.shade.relocation.Relocator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -63,6 +64,25 @@ public class ApacheNoticeResourceTransformerTest {
         assertTrue(transformer.canTransformResource("META-INF/Notice.txt"));
         assertTrue(transformer.canTransformResource("META-INF/Notice.md"));
         assertFalse(transformer.canTransformResource("META-INF/MANIFEST.MF"));
+    }
+
+    @Test
+    public void testProjectNameDefaultsToMavenProjectName() {
+        transformer.setProjectNameIfUnset(null);
+        transformer.setProjectNameIfUnset(" ");
+        assertEquals("", transformer.projectName);
+
+        transformer.setProjectNameIfUnset("Maven Project Name");
+        assertEquals("Maven Project Name", transformer.projectName);
+    }
+
+    @Test
+    public void testConfiguredProjectNameTakesPrecedence() {
+        transformer.projectName = "Configured Project Name";
+
+        transformer.setProjectNameIfUnset("Maven Project Name");
+
+        assertEquals("Configured Project Name", transformer.projectName);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Use the Maven project name as the default project name in notices generated by
`ApacheNoticeResourceTransformer`.

The transformer previously initialized `projectName` to an empty string and the
mojo never supplied the injected `MavenProject`. Consequently, configuring the
transformer without an explicit `<projectName>` produced a blank generated
NOTICE header even when the POM had a nonblank `<name>`.

`ShadeMojo` now supplies `MavenProject#getName()` when the transformer project
name is unset and the Maven project name is neither null nor blank. Explicit
transformer configuration remains authoritative, and a missing or blank Maven
project name preserves the previous empty behavior.

The change includes unit coverage for the fallback rules, a failing-first
integration test for the generated NOTICE, and documentation of the default.

Fixes #742.

## Validation

- `mvn -Prun-its clean verify`: 74 unit tests and 84 integration projects
  passed; two projects were skipped by their JRE-version conditions.
- JDK 21 `mvn test`: 74 tests passed.
- Maven 4 built the isolated regression project with the branch plugin and
  generated the expected NOTICE header.
- `mvn site` passed.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHADE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.

       This change is tracked by GitHub issue #742; no separate JIRA issue was opened.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHADE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHADE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.

       The title uses `#742`, the repository's GitHub tracking issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
