### PR TITLE
[MSHADE-460] - Preserve multi-release JAR semantics

### DIFF
--- a/src/it/projects/MSHADE-406/app/pom.xml
+++ b/src/it/projects/MSHADE-406/app/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.shade.mshade406</groupId>
+    <artifactId>mshade-406-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>app</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.shade.mshade406</groupId>
+      <artifactId>dependency</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@version.maven-compiler-plugin@</version>
+        <configuration>
+          <release>8</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <minimizeJar>true</minimizeJar>
+              <relocations>
+                <relocation>
+                  <pattern>reproducer.mr</pattern>
+                  <shadedPattern>reproducer.shaded.mr</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>reproducer.app.Main</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-406/app/src/main/java/reproducer/app/Main.java
+++ b/src/it/projects/MSHADE-406/app/src/main/java/reproducer/app/Main.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package reproducer.app;
+
+import reproducer.mr.Versioned;
+
+public final class Main {
+    public static void main(String[] args) {
+        System.out.println(Versioned.value());
+    }
+}

--- a/src/it/projects/MSHADE-406/app/src/main/java/reproducer/app/Main.java
+++ b/src/it/projects/MSHADE-406/app/src/main/java/reproducer/app/Main.java
@@ -18,10 +18,20 @@
  */
 package reproducer.app;
 
+import java.io.InputStream;
+import java.util.Properties;
+
 import reproducer.mr.Versioned;
 
 public final class Main {
-    public static void main(String[] args) {
-        System.out.println(Versioned.value());
+    public static void main(String[] args) throws Exception {
+        try (InputStream input = Versioned.class.getResourceAsStream("config.properties")) {
+            if (input == null) {
+                throw new IllegalStateException("Missing relocated resource");
+            }
+            Properties properties = new Properties();
+            properties.load(input);
+            System.out.println(Versioned.value() + ":" + properties.getProperty("value"));
+        }
     }
 }

--- a/src/it/projects/MSHADE-406/dependency/pom.xml
+++ b/src/it/projects/MSHADE-406/dependency/pom.xml
@@ -31,6 +31,15 @@ under the License.
   <artifactId>dependency</artifactId>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/main/resources11</directory>
+        <targetPath>META-INF/versions/11</targetPath>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/src/it/projects/MSHADE-406/dependency/pom.xml
+++ b/src/it/projects/MSHADE-406/dependency/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.shade.mshade406</groupId>
+    <artifactId>mshade-406-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>dependency</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@version.maven-compiler-plugin@</version>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <release>8</release>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-java11</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>11</release>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+              </compileSourceRoots>
+              <outputDirectory>${project.build.outputDirectory}/META-INF/versions/11</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>@version.maven-jar-plugin@</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Multi-Release>true</Multi-Release>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-406/dependency/src/main/java/reproducer/mr/Unused.java
+++ b/src/it/projects/MSHADE-406/dependency/src/main/java/reproducer/mr/Unused.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package reproducer.mr;
+
+public final class Unused {}

--- a/src/it/projects/MSHADE-406/dependency/src/main/java/reproducer/mr/Versioned.java
+++ b/src/it/projects/MSHADE-406/dependency/src/main/java/reproducer/mr/Versioned.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package reproducer.mr;
+
+public final class Versioned {
+    public static String value() {
+        return "base";
+    }
+}

--- a/src/it/projects/MSHADE-406/dependency/src/main/java11/module-info.java
+++ b/src/it/projects/MSHADE-406/dependency/src/main/java11/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module reproducer.mr {
+    exports reproducer.mr;
+}

--- a/src/it/projects/MSHADE-406/dependency/src/main/java11/reproducer/mr/Unused.java
+++ b/src/it/projects/MSHADE-406/dependency/src/main/java11/reproducer/mr/Unused.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package reproducer.mr;
+
+public final class Unused {}

--- a/src/it/projects/MSHADE-406/dependency/src/main/java11/reproducer/mr/Versioned.java
+++ b/src/it/projects/MSHADE-406/dependency/src/main/java11/reproducer/mr/Versioned.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package reproducer.mr;
+
+public final class Versioned {
+    public static String value() {
+        return "java11";
+    }
+}

--- a/src/it/projects/MSHADE-406/dependency/src/main/resources/reproducer/mr/config.properties
+++ b/src/it/projects/MSHADE-406/dependency/src/main/resources/reproducer/mr/config.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+value=root-resource

--- a/src/it/projects/MSHADE-406/dependency/src/main/resources11/reproducer/mr/config.properties
+++ b/src/it/projects/MSHADE-406/dependency/src/main/resources11/reproducer/mr/config.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+value=java11-resource

--- a/src/it/projects/MSHADE-406/invoker.properties
+++ b/src/it/projects/MSHADE-406/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 17+

--- a/src/it/projects/MSHADE-406/pom.xml
+++ b/src/it/projects/MSHADE-406/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.mshade406</groupId>
+  <artifactId>mshade-406-parent</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>dependency</module>
+    <module>app</module>
+  </modules>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/it/projects/MSHADE-406/verify.groovy
+++ b/src/it/projects/MSHADE-406/verify.groovy
@@ -27,9 +27,15 @@ try
     assert jar.getJarEntry( "reproducer/shaded/mr/Versioned.class" ) != null
     assert jar.getJarEntry(
             "META-INF/versions/11/reproducer/shaded/mr/Versioned.class" ) != null
+    assert jar.getJarEntry( "reproducer/shaded/mr/config.properties" ) != null
+    assert jar.getJarEntry(
+            "META-INF/versions/11/reproducer/shaded/mr/config.properties" ) != null
 
     assert jar.getJarEntry( "reproducer/mr/Versioned.class" ) == null
     assert jar.getJarEntry( "META-INF/versions/11/reproducer/mr/Versioned.class" ) == null
+    assert jar.getJarEntry( "reproducer/mr/config.properties" ) == null
+    assert jar.getJarEntry(
+            "META-INF/versions/11/reproducer/mr/config.properties" ) == null
 
     assert jar.getJarEntry( "reproducer/shaded/mr/Unused.class" ) == null
     assert jar.getJarEntry(
@@ -47,4 +53,4 @@ def process = new ProcessBuilder( java.absolutePath, "-jar", shadedJar.absoluteP
         .start()
 def output = process.inputStream.getText( "UTF-8" )
 assert process.waitFor() == 0 : output
-assert output.trim() == "java11"
+assert output.trim() == "java11:java11-resource"

--- a/src/it/projects/MSHADE-406/verify.groovy
+++ b/src/it/projects/MSHADE-406/verify.groovy
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def shadedJar = new File( basedir, "app/target/app-1.0.jar" )
+assert shadedJar.isFile()
+
+def jar = new java.util.jar.JarFile( shadedJar )
+try
+{
+    assert jar.manifest.mainAttributes.getValue( "Multi-Release" ) == "true"
+    assert jar.getJarEntry( "reproducer/shaded/mr/Versioned.class" ) != null
+    assert jar.getJarEntry(
+            "META-INF/versions/11/reproducer/shaded/mr/Versioned.class" ) != null
+
+    assert jar.getJarEntry( "reproducer/mr/Versioned.class" ) == null
+    assert jar.getJarEntry( "META-INF/versions/11/reproducer/mr/Versioned.class" ) == null
+
+    assert jar.getJarEntry( "reproducer/shaded/mr/Unused.class" ) == null
+    assert jar.getJarEntry(
+            "META-INF/versions/11/reproducer/shaded/mr/Unused.class" ) == null
+    assert jar.getJarEntry( "META-INF/versions/11/module-info.class" ) == null
+}
+finally
+{
+    jar.close()
+}
+
+def java = new File( System.getProperty( "java.home" ), "bin/java" )
+def process = new ProcessBuilder( java.absolutePath, "-jar", shadedJar.absolutePath )
+        .redirectErrorStream( true )
+        .start()
+def output = process.inputStream.getText( "UTF-8" )
+assert process.waitFor() == 0 : output
+assert output.trim() == "java11"

--- a/src/it/projects/MSHADE-460/invoker.properties
+++ b/src/it/projects/MSHADE-460/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 17+

--- a/src/it/projects/MSHADE-460/pom.xml
+++ b/src/it/projects/MSHADE-460/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.shade.mshade460</groupId>
+  <artifactId>mshade-460</artifactId>
+  <version>1.0</version>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.json.bind</groupId>
+      <artifactId>jakarta.json.bind-api</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse</groupId>
+      <artifactId>yasson</artifactId>
+      <version>3.0.3</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@version.maven-compiler-plugin@</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.apache.maven.its.shade.mshade460.Main</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-460/src/main/java/org/apache/maven/its/shade/mshade460/Main.java
+++ b/src/it/projects/MSHADE-460/src/main/java/org/apache/maven/its/shade/mshade460/Main.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.shade.mshade460;
+
+import java.time.Instant;
+
+import jakarta.json.bind.JsonbBuilder;
+
+public final class Main {
+    public record TimeInfo(Instant datetime) {}
+
+    public static void main(String[] args) {
+        TimeInfo value = JsonbBuilder.create()
+                .fromJson("{\"datetime\":\"2023-10-29T12:00:00Z\"}", TimeInfo.class);
+        System.out.println(value);
+    }
+}

--- a/src/it/projects/MSHADE-460/verify.groovy
+++ b/src/it/projects/MSHADE-460/verify.groovy
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def shadedJar = new File( basedir, "target/mshade-460-1.0.jar" )
+assert shadedJar.isFile()
+
+def jar = new java.util.jar.JarFile( shadedJar )
+try
+{
+    assert jar.manifest.mainAttributes.getValue( "Multi-Release" ) == "true"
+    assert jar.getJarEntry(
+            "META-INF/versions/16/org/eclipse/yasson/internal/ClassMultiReleaseExtension.class" ) != null
+}
+finally
+{
+    jar.close()
+}
+
+def java = new File( System.getProperty( "java.home" ), "bin/java" )
+def process = new ProcessBuilder( java.absolutePath, "-jar", shadedJar.absolutePath )
+        .redirectErrorStream( true )
+        .start()
+def output = process.inputStream.getText( "UTF-8" )
+assert process.waitFor() == 0 : output
+assert output.trim() == "TimeInfo[datetime=2023-10-29T12:00:00Z]"

--- a/src/main/java/org/apache/maven/plugins/shade/DefaultShader.java
+++ b/src/main/java/org/apache/maven/plugins/shade/DefaultShader.java
@@ -52,6 +52,7 @@ import java.util.concurrent.Callable;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.CRC32;
@@ -81,6 +82,12 @@ import org.slf4j.LoggerFactory;
 @Named
 public class DefaultShader implements Shader {
     private static final int BUFFER_SIZE = 32 * 1024;
+
+    private static final Pattern MULTI_RELEASE_ENTRY_PATH =
+            Pattern.compile("^(META-INF/versions/(?:9|[1-9][0-9]+)/)(.+)$");
+
+    private static final Pattern VERSIONED_MODULE_INFO =
+            Pattern.compile("^META-INF/versions/(?:9|[1-9][0-9]+)/module-info[.]class$");
 
     private final Logger logger;
 
@@ -142,6 +149,9 @@ public class DefaultShader implements Shader {
                 manifestTransformer = (ManifestResourceTransformer) transformer;
                 it.remove();
             }
+        }
+        if (manifestTransformer == null && containsMultiReleaseJar(shadeRequest.getJars())) {
+            manifestTransformer = new ManifestResourceTransformer();
         }
 
         final DefaultPackageMapper packageMapper = new DefaultPackageMapper(shadeRequest.getRelocators());
@@ -393,7 +403,8 @@ public class DefaultShader implements Shader {
             return true;
         }
 
-        if ("module-info.class".equals(name)) {
+        if ("module-info.class".equals(name)
+                || VERSIONED_MODULE_INFO.matcher(name).matches()) {
             logger.warn("Discovered module-info.class. " + "Shading will break its strong encapsulation.");
             return true;
         }
@@ -415,7 +426,7 @@ public class DefaultShader implements Shader {
             int method)
             throws Exception {
         try (InputStream in = inputProvider.call()) {
-            String mappedName = packageMapper.map(name, true, false);
+            String mappedName = ArchiveEntry.parse(name).map(packageMapper);
 
             int idx = mappedName.lastIndexOf('/');
             if (idx != -1) {
@@ -460,25 +471,69 @@ public class DefaultShader implements Shader {
             throws IOException {
         if (manifestTransformer != null) {
             for (File jar : shadeRequest.getJars()) {
-                try (JarFile jarFile = newJarFile(jar)) {
-                    for (Enumeration<JarEntry> en = jarFile.entries(); en.hasMoreElements(); ) {
-                        JarEntry entry = en.nextElement();
-                        String resource = entry.getName();
-                        if (manifestTransformer.canTransformResource(resource)) {
-                            resources.add(resource);
-                            try (InputStream inputStream = jarFile.getInputStream(entry)) {
-                                manifestTransformer.processResource(
-                                        resource, inputStream, shadeRequest.getRelocators(), getTime(entry));
-                            }
-                            break;
+                if (jar.isDirectory()) {
+                    File manifestFile = new File(jar, JarFile.MANIFEST_NAME);
+                    if (manifestFile.isFile()) {
+                        resources.add(JarFile.MANIFEST_NAME);
+                        try (InputStream inputStream = Files.newInputStream(manifestFile.toPath())) {
+                            manifestTransformer.processResource(
+                                    JarFile.MANIFEST_NAME,
+                                    inputStream,
+                                    shadeRequest.getRelocators(),
+                                    manifestFile.lastModified());
                         }
                     }
+                } else {
+                    processManifest(jar, shadeRequest, resources, manifestTransformer);
                 }
             }
             if (manifestTransformer.hasTransformedResource()) {
                 manifestTransformer.modifyOutputStream(jos);
             }
         }
+    }
+
+    private void processManifest(
+            File jar, ShadeRequest shadeRequest, Set<String> resources, ManifestResourceTransformer manifestTransformer)
+            throws IOException {
+        try (JarFile jarFile = newJarFile(jar)) {
+            for (Enumeration<JarEntry> en = jarFile.entries(); en.hasMoreElements(); ) {
+                JarEntry entry = en.nextElement();
+                String resource = entry.getName();
+                if (manifestTransformer.canTransformResource(resource)) {
+                    resources.add(resource);
+                    try (InputStream inputStream = jarFile.getInputStream(entry)) {
+                        manifestTransformer.processResource(
+                                resource, inputStream, shadeRequest.getRelocators(), getTime(entry));
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    private boolean containsMultiReleaseJar(Collection<File> jars) throws IOException {
+        for (File jar : jars) {
+            Manifest manifest;
+            if (jar.isDirectory()) {
+                File manifestFile = new File(jar, JarFile.MANIFEST_NAME);
+                if (!manifestFile.isFile()) {
+                    continue;
+                }
+                try (InputStream inputStream = Files.newInputStream(manifestFile.toPath())) {
+                    manifest = new Manifest(inputStream);
+                }
+            } else {
+                try (JarFile jarFile = newJarFile(jar)) {
+                    manifest = jarFile.getManifest();
+                }
+            }
+            if (manifest != null
+                    && Boolean.parseBoolean(manifest.getMainAttributes().getValue("Multi-Release"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void showOverlappingWarning() {
@@ -619,7 +674,8 @@ public class DefaultShader implements Shader {
         // that use the constant pool to determine the dependencies of a class.
         ClassWriter cw = new ClassWriter(0);
 
-        final String pkg = name.substring(0, name.lastIndexOf('/') + 1);
+        ArchiveEntry classEntry = ArchiveEntry.parse(name);
+        final String pkg = classEntry.logicalName.substring(0, classEntry.logicalName.lastIndexOf('/') + 1);
         final ShadeClassRemapper cv = new ShadeClassRemapper(cw, pkg, packageMapper);
 
         try {
@@ -638,18 +694,43 @@ public class DefaultShader implements Shader {
             renamedClass = originalClass;
         }
 
-        // Need to take the .class off for remapping evaluation
-        String mappedName = packageMapper.map(name.substring(0, name.indexOf('.')), true, false);
+        String mappedName = classEntry.mapClass(packageMapper);
 
         try {
-            // Now we put it back on so the class file is written out with the right extension.
-            JarEntry entry = new JarEntry(mappedName + ".class");
+            JarEntry entry = new JarEntry(mappedName);
             entry.setTime(time);
             jos.putNextEntry(entry);
 
             jos.write(renamedClass);
         } catch (ZipException e) {
             logger.debug("We have a duplicate " + mappedName + " in " + jar);
+        }
+    }
+
+    private static final class ArchiveEntry {
+        private final String versionPrefix;
+
+        private final String logicalName;
+
+        private ArchiveEntry(String versionPrefix, String logicalName) {
+            this.versionPrefix = versionPrefix;
+            this.logicalName = logicalName;
+        }
+
+        private static ArchiveEntry parse(String name) {
+            Matcher matcher = MULTI_RELEASE_ENTRY_PATH.matcher(name);
+            return matcher.matches()
+                    ? new ArchiveEntry(matcher.group(1), matcher.group(2))
+                    : new ArchiveEntry("", name);
+        }
+
+        private String map(PackageMapper packageMapper) {
+            return versionPrefix + packageMapper.map(logicalName, true, false);
+        }
+
+        private String mapClass(PackageMapper packageMapper) {
+            String name = logicalName.substring(0, logicalName.length() - ".class".length());
+            return versionPrefix + packageMapper.map(name, true, false) + ".class";
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
+++ b/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
@@ -327,11 +327,15 @@ public class MinijarFilter implements Filter {
 
     @Override
     public boolean isFiltered(String classFile) {
-        String className = classFile.replace('/', '.').replaceFirst("\\.class$", "");
-        Clazz clazz = new Clazz(className);
+        Clazz.ParsedFileName parsedFileName = Clazz.parseClassFileName(classFile);
+        if (parsedFileName == null) {
+            classesKept += 1;
+            return false;
+        }
+        Clazz clazz = new Clazz(parsedFileName.className);
 
         if (removable != null && removable.contains(clazz)) {
-            log.debug("Removing " + className);
+            log.debug("Removing " + parsedFileName.className);
             classesRemoved += 1;
             return true;
         }

--- a/src/main/java/org/apache/maven/plugins/shade/resource/ManifestResourceTransformer.java
+++ b/src/main/java/org/apache/maven/plugins/shade/resource/ManifestResourceTransformer.java
@@ -30,6 +30,8 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
 import org.apache.maven.plugins.shade.relocation.Relocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A resource processor that allows the arbitrary addition of attributes to
@@ -40,6 +42,10 @@ import org.apache.maven.plugins.shade.relocation.Relocator;
  * @since 1.2
  */
 public class ManifestResourceTransformer extends AbstractCompatibilityTransformer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ManifestResourceTransformer.class);
+
+    private static final Attributes.Name MULTI_RELEASE = new Attributes.Name("Multi-Release");
+
     private final List<String> defaultAttributes =
             Arrays.asList("Export-Package", "Import-Package", "Provide-Capability", "Require-Capability");
 
@@ -54,6 +60,8 @@ public class ManifestResourceTransformer extends AbstractCompatibilityTransforme
     private boolean manifestDiscovered;
 
     private Manifest manifest;
+
+    private boolean multiRelease;
 
     private long time = Long.MIN_VALUE;
 
@@ -79,11 +87,15 @@ public class ManifestResourceTransformer extends AbstractCompatibilityTransforme
     @Override
     public void processResource(String resource, InputStream is, List<Relocator> relocators, long time)
             throws IOException {
+        Manifest incomingManifest = new Manifest(is);
+        multiRelease |=
+                Boolean.parseBoolean(incomingManifest.getMainAttributes().getValue(MULTI_RELEASE));
+
         // We just want to take the first manifest we come across as that's our project's manifest. This is the behavior
         // now which is situational at best. Right now there is no context passed in with the processing so we cannot
         // tell what artifact is being processed.
         if (!manifestDiscovered) {
-            manifest = new Manifest(is);
+            manifest = incomingManifest;
 
             if (relocators != null && !relocators.isEmpty()) {
                 final Attributes attributes = manifest.getMainAttributes();
@@ -129,6 +141,10 @@ public class ManifestResourceTransformer extends AbstractCompatibilityTransforme
 
         Attributes attributes = manifest.getMainAttributes();
 
+        if (multiRelease && attributes.getValue(MULTI_RELEASE) == null) {
+            attributes.put(MULTI_RELEASE, Boolean.TRUE.toString());
+        }
+
         if (mainClass != null) {
             attributes.put(Attributes.Name.MAIN_CLASS, mainClass);
         }
@@ -141,6 +157,11 @@ public class ManifestResourceTransformer extends AbstractCompatibilityTransforme
                     attributes.put(new Attributes.Name(entry.getKey()), entry.getValue());
                 }
             }
+        }
+
+        if (multiRelease && !Boolean.parseBoolean(attributes.getValue(MULTI_RELEASE))) {
+            LOGGER.warn("Shaded inputs contain a multi-release JAR, but the shaded JAR is explicitly configured "
+                    + "with Multi-Release: false. Versioned classes will not be active.");
         }
 
         JarEntry jarEntry = new JarEntry(JarFile.MANIFEST_NAME);

--- a/src/test/java/org/apache/maven/plugins/shade/DefaultShaderTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/DefaultShaderTest.java
@@ -45,6 +45,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
 import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
@@ -150,6 +151,32 @@ public class DefaultShaderTest {
             }
         }
         assertEquals(3 /* 1 | 2 */, result);
+    }
+
+    @Test
+    public void testMultiReleaseManifestIsPropagatedWithoutTransformer() throws Exception {
+        TemporaryFolder temporaryFolder = new TemporaryFolder();
+        try {
+            temporaryFolder.create();
+            File projectJar = createJar(temporaryFolder.newFile("project.jar"), false);
+            File dependencyJar = createJar(temporaryFolder.newFile("dependency.jar"), true);
+            File shadedJar = temporaryFolder.newFile("shaded.jar");
+
+            ShadeRequest shadeRequest = new ShadeRequest();
+            shadeRequest.setJars(new LinkedHashSet<>(Arrays.asList(projectJar, dependencyJar)));
+            shadeRequest.setRelocators(Collections.emptyList());
+            shadeRequest.setResourceTransformers(Collections.emptyList());
+            shadeRequest.setFilters(Collections.emptyList());
+            shadeRequest.setUberJar(shadedJar);
+
+            newShader().shade(shadeRequest);
+
+            try (JarFile jarFile = new JarFile(shadedJar)) {
+                assertEquals("true", jarFile.getManifest().getMainAttributes().getValue("Multi-Release"));
+            }
+        } finally {
+            temporaryFolder.delete();
+        }
     }
 
     @Test
@@ -564,6 +591,19 @@ public class DefaultShaderTest {
         jos.putNextEntry(entry);
         jos.write(entryBytes);
         jos.closeEntry();
+    }
+
+    private File createJar(File file, boolean multiRelease) throws IOException {
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue("Manifest-Version", "1.0");
+        if (multiRelease) {
+            manifest.getMainAttributes().putValue("Multi-Release", "true");
+        }
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(file.toPath()), manifest)) {
+            jos.putNextEntry(new JarEntry((multiRelease ? "dependency" : "project") + ".txt"));
+            jos.closeEntry();
+        }
+        return file;
     }
 
     private void shaderWithPattern(String shadedPattern, File jar, String[] excludes) throws Exception {

--- a/src/test/java/org/apache/maven/plugins/shade/resource/ManifestResourceTransformerTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/resource/ManifestResourceTransformerTest.java
@@ -168,14 +168,69 @@ public class ManifestResourceTransformerTest {
         }
     }
 
+    @Test
+    public void preserveMultiReleaseFromSubsequentManifest() throws Exception {
+        processManifest(createTestManifest(), Collections.<Relocator>emptyList());
+
+        Manifest dependencyManifest = new Manifest();
+        dependencyManifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        dependencyManifest.getMainAttributes().putValue("Multi-Release", "true");
+        processManifest(dependencyManifest, Collections.<Relocator>emptyList());
+
+        try (JarInputStream jis =
+                new JarInputStream(new ByteArrayInputStream(writeOutput().toByteArray()))) {
+            assertEquals("true", jis.getManifest().getMainAttributes().getValue("Multi-Release"));
+        }
+    }
+
+    @Test
+    public void preserveExplicitMultiReleaseFalse() throws Exception {
+        Manifest projectManifest = createTestManifest();
+        projectManifest.getMainAttributes().putValue("Multi-Release", "false");
+        processManifest(projectManifest, Collections.<Relocator>emptyList());
+
+        Manifest dependencyManifest = new Manifest();
+        dependencyManifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        dependencyManifest.getMainAttributes().putValue("Multi-Release", "true");
+        processManifest(dependencyManifest, Collections.<Relocator>emptyList());
+
+        try (JarInputStream jis =
+                new JarInputStream(new ByteArrayInputStream(writeOutput().toByteArray()))) {
+            assertEquals("false", jis.getManifest().getMainAttributes().getValue("Multi-Release"));
+        }
+    }
+
+    @Test
+    public void preserveConfiguredMultiReleaseFalse() throws Exception {
+        processManifest(createTestManifest(), Collections.<Relocator>emptyList());
+
+        Manifest dependencyManifest = new Manifest();
+        dependencyManifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        dependencyManifest.getMainAttributes().putValue("Multi-Release", "true");
+        processManifest(dependencyManifest, Collections.<Relocator>emptyList());
+        transformer.setManifestEntries(Collections.<String, Object>singletonMap("Multi-Release", "false"));
+
+        try (JarInputStream jis =
+                new JarInputStream(new ByteArrayInputStream(writeOutput().toByteArray()))) {
+            assertEquals("false", jis.getManifest().getMainAttributes().getValue("Multi-Release"));
+        }
+    }
+
     private ByteArrayOutputStream transform(final Manifest manifest, List<Relocator> relocators) throws IOException {
+        processManifest(manifest, relocators);
+        return writeOutput();
+    }
+
+    private void processManifest(final Manifest manifest, List<Relocator> relocators) throws IOException {
         final ByteArrayOutputStream mboas = new ByteArrayOutputStream();
         try (OutputStream mos = mboas) {
             manifest.write(mos);
         }
         transformer.processResource(
                 JarFile.MANIFEST_NAME, new ByteArrayInputStream(mboas.toByteArray()), relocators, 0);
+    }
 
+    private ByteArrayOutputStream writeOutput() throws IOException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (JarOutputStream jarOutputStream = new JarOutputStream(out)) {
             transformer.modifyOutputStream(jarOutputStream);


### PR DESCRIPTION
Fixes #672.
Fixes #652.
Fixes #463.
Fixes #696.

## Summary

Preserve multi-release JAR semantics when dependencies are incorporated into a
shaded artifact.

The shaded manifest now receives `Multi-Release: true` when any included input
is a multi-release JAR. An explicit `Multi-Release: false` remains authoritative
and produces a warning explaining that versioned entries will not be active.

Relocation now operates on the logical path below
`META-INF/versions/<release>/`, so versioned classes and resources remain
aligned with their root entries. Minimization likewise treats all physical
versions of a class as the same logical class. Root and versioned
`module-info.class` entries continue to be discarded; this change does not
introduce module descriptor merging.

## Root cause

Shade copied versioned entries but retained only the first input manifest.
This could leave the versioned entries inactive. Relocation also evaluated the
physical `META-INF/versions/<release>/...` path, which prevented ordinary
package relocation rules from matching versioned classes and resources.
Finally, minimization treated a versioned class path as a distinct class name.

## Tests

The new integration coverage:

* reproduces the record-deserialization failure from MSHADE-460 using Yasson;
* verifies manifest propagation;
* verifies root and Java 11 class and resource relocation;
* verifies runtime selection of the relocated Java 11 resource;
* verifies minimization across release variants; and
* verifies removal of a versioned module descriptor.

Validation performed with JDK 17:

* `mvn clean verify` — 76 tests passed;
* `mvn -Prun-its clean verify` — 86 integration projects passed and one
  existing JRE-gated project was skipped.

Both generated multi-release JARs also pass JDK 21 `jar --validate` and execute
successfully on JDK 21.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHADE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHADE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHADE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
