### PR TITLE
[MSHADE-154] Add ability to shade an attached primary artifact

### DIFF
--- a/src/it/projects/MSHADE-154-incompatible-input-type/invoker.properties
+++ b/src/it/projects/MSHADE-154-incompatible-input-type/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean package
+invoker.buildResult = failure

--- a/src/it/projects/MSHADE-154-incompatible-input-type/payload/example.txt
+++ b/src/it/projects/MSHADE-154-incompatible-input-type/payload/example.txt
@@ -1,0 +1,18 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+must not become a POM

--- a/src/it/projects/MSHADE-154-incompatible-input-type/pom.xml
+++ b/src/it/projects/MSHADE-154-incompatible-input-type/pom.xml
@@ -32,39 +32,50 @@ under the License.
   </parent>
 
   <groupId>org.apache.maven.its.shade.mshade154</groupId>
-  <artifactId>parent</artifactId>
+  <artifactId>incompatible-input</artifactId>
   <version>1.0</version>
   <packaging>pom</packaging>
 
-  <name>MSHADE-154</name>
-  <description>Test shading an attached artifact selected by classifier.</description>
-
-  <modules>
-    <module>dependency</module>
-    <module>app</module>
-    <module>pom-input</module>
-  </modules>
-
-  <properties>
-    <maven.compiler.release>8</maven.compiler.release>
-  </properties>
+  <name>MSHADE-154 incompatible input</name>
+  <description>Reject replacing a POM main artifact with an attached JAR.</description>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>@version.maven-compiler-plugin@</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>@version.maven-install-plugin@</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>@version.maven-jar-plugin@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>@version.maven-jar-plugin@</version>
+        <executions>
+          <execution>
+            <id>attach-input</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>thin</classifier>
+              <classesDirectory>${project.basedir}/payload</classesDirectory>
+              <skipIfEmpty>false</skipIfEmpty>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <inputClassifier>thin</inputClassifier>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/src/it/projects/MSHADE-154-incompatible-input-type/verify.groovy
+++ b/src/it/projects/MSHADE-154-incompatible-input-type/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert !new File(basedir, "target/incompatible-input-1.0.pom").exists()
+assert new File(basedir, "pom.xml").text.startsWith("<?xml")

--- a/src/it/projects/MSHADE-154-input-classifier/app/pom.xml
+++ b/src/it/projects/MSHADE-154-input-classifier/app/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.shade.mshade154</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>app</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>dependency</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <classifier>thin</classifier>
+          <includes>
+            <include>example/App.class</include>
+            <include>input-resource.txt</include>
+            <include>filtered-out.txt</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <inputClassifier>thin</inputClassifier>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <minimizeJar>true</minimizeJar>
+              <filters>
+                <filter>
+                  <artifact>${project.groupId}:${project.artifactId}:jar:thin</artifact>
+                  <excludes>
+                    <exclude>filtered-out.txt</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-154-input-classifier/app/src/main/java/example/App.java
+++ b/src/it/projects/MSHADE-154-input-classifier/app/src/main/java/example/App.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package example;
+
+import dependency.Used;
+
+public class App {
+    public static String message() {
+        return Used.message();
+    }
+}

--- a/src/it/projects/MSHADE-154-input-classifier/app/src/main/java/example/Excluded.java
+++ b/src/it/projects/MSHADE-154-input-classifier/app/src/main/java/example/Excluded.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package example;
+
+public class Excluded {}

--- a/src/it/projects/MSHADE-154-input-classifier/app/src/main/resources/filtered-out.txt
+++ b/src/it/projects/MSHADE-154-input-classifier/app/src/main/resources/filtered-out.txt
@@ -1,0 +1,18 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+filtered from shaded output

--- a/src/it/projects/MSHADE-154-input-classifier/app/src/main/resources/input-resource.txt
+++ b/src/it/projects/MSHADE-154-input-classifier/app/src/main/resources/input-resource.txt
@@ -1,0 +1,18 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+selected input

--- a/src/it/projects/MSHADE-154-input-classifier/dependency/pom.xml
+++ b/src/it/projects/MSHADE-154-input-classifier/dependency/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.shade.mshade154</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>dependency</artifactId>
+</project>

--- a/src/it/projects/MSHADE-154-input-classifier/dependency/src/main/java/dependency/Unused.java
+++ b/src/it/projects/MSHADE-154-input-classifier/dependency/src/main/java/dependency/Unused.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package dependency;
+
+public class Unused {
+    public static String message() {
+        return "unused";
+    }
+}

--- a/src/it/projects/MSHADE-154-input-classifier/dependency/src/main/java/dependency/Used.java
+++ b/src/it/projects/MSHADE-154-input-classifier/dependency/src/main/java/dependency/Used.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package dependency;
+
+public class Used {
+    public static String message() {
+        return "used";
+    }
+}

--- a/src/it/projects/MSHADE-154-input-classifier/invoker.properties
+++ b/src/it/projects/MSHADE-154-input-classifier/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean install

--- a/src/it/projects/MSHADE-154-input-classifier/pom-input/payload/example.txt
+++ b/src/it/projects/MSHADE-154-input-classifier/pom-input/payload/example.txt
@@ -1,0 +1,18 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+attached JAR input

--- a/src/it/projects/MSHADE-154-input-classifier/pom-input/pom.xml
+++ b/src/it/projects/MSHADE-154-input-classifier/pom-input/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.shade.mshade154</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>pom-input</artifactId>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-input</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>thin</classifier>
+              <classesDirectory>${project.basedir}/payload</classesDirectory>
+              <skipIfEmpty>false</skipIfEmpty>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <inputClassifier>thin</inputClassifier>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-154-input-classifier/pom-input/pom.xml
+++ b/src/it/projects/MSHADE-154-input-classifier/pom-input/pom.xml
@@ -50,6 +50,42 @@ under the License.
               <skipIfEmpty>false</skipIfEmpty>
             </configuration>
           </execution>
+          <execution>
+            <id>attach-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>sources</classifier>
+              <classesDirectory>${project.basedir}/payload</classesDirectory>
+              <skipIfEmpty>false</skipIfEmpty>
+            </configuration>
+          </execution>
+          <execution>
+            <id>attach-tests</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>tests</classifier>
+              <classesDirectory>${project.basedir}/payload</classesDirectory>
+              <skipIfEmpty>false</skipIfEmpty>
+            </configuration>
+          </execution>
+          <execution>
+            <id>attach-test-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>test-sources</classifier>
+              <classesDirectory>${project.basedir}/payload</classesDirectory>
+              <skipIfEmpty>false</skipIfEmpty>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -65,6 +101,9 @@ under the License.
             <configuration>
               <inputClassifier>thin</inputClassifier>
               <shadedArtifactAttached>true</shadedArtifactAttached>
+              <createSourcesJar>true</createSourcesJar>
+              <shadeTestJar>true</shadeTestJar>
+              <createTestSourcesJar>true</createTestSourcesJar>
               <createDependencyReducedPom>false</createDependencyReducedPom>
             </configuration>
           </execution>

--- a/src/it/projects/MSHADE-154-input-classifier/pom.xml
+++ b/src/it/projects/MSHADE-154-input-classifier/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.shade.its</groupId>
+    <artifactId>shade-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../setup-parent</relativePath>
+  </parent>
+
+  <groupId>org.apache.maven.its.shade.mshade154</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>MSHADE-154</name>
+  <description>Test shading an attached artifact selected by classifier.</description>
+
+  <modules>
+    <module>dependency</module>
+    <module>app</module>
+  </modules>
+
+  <properties>
+    <maven.compiler.release>8</maven.compiler.release>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>@version.maven-compiler-plugin@</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>@version.maven-install-plugin@</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>@version.maven-jar-plugin@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-154-input-classifier/pom.xml
+++ b/src/it/projects/MSHADE-154-input-classifier/pom.xml
@@ -43,6 +43,7 @@ under the License.
     <module>dependency</module>
     <module>app</module>
     <module>pom-input</module>
+    <module>zip-input</module>
   </modules>
 
   <properties>

--- a/src/it/projects/MSHADE-154-input-classifier/verify.groovy
+++ b/src/it/projects/MSHADE-154-input-classifier/verify.groovy
@@ -46,3 +46,16 @@ try {
 } finally {
     inputJar.close()
 }
+
+File pomInputFile = new File(basedir, "pom-input/target/pom-input-1.0-shaded.jar")
+assert pomInputFile.isFile()
+assert !new File(basedir, "pom-input/target/pom-input-1.0-shaded.pom").exists()
+
+JarFile pomInputJar = new JarFile(pomInputFile)
+try {
+    assert pomInputJar.getEntry("example.txt") != null
+} finally {
+    pomInputJar.close()
+}
+
+assert new File(basedir, "pom-input/pom.xml").text.startsWith("<?xml")

--- a/src/it/projects/MSHADE-154-input-classifier/verify.groovy
+++ b/src/it/projects/MSHADE-154-input-classifier/verify.groovy
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.jar.JarFile
+
+File mainFile = new File(basedir, "app/target/app-1.0.jar")
+assert mainFile.isFile()
+
+JarFile mainJar = new JarFile(mainFile)
+try {
+    assert mainJar.getEntry("example/App.class") != null
+    assert mainJar.getEntry("dependency/Used.class") != null
+    assert mainJar.getEntry("input-resource.txt") != null
+    assert mainJar.getEntry("example/Excluded.class") == null
+    assert mainJar.getEntry("dependency/Unused.class") == null
+    assert mainJar.getEntry("filtered-out.txt") == null
+} finally {
+    mainJar.close()
+}
+
+File inputFile = new File(basedir, "app/target/app-1.0-thin.jar")
+assert inputFile.isFile()
+
+JarFile inputJar = new JarFile(inputFile)
+try {
+    assert inputJar.getEntry("example/App.class") != null
+    assert inputJar.getEntry("input-resource.txt") != null
+    assert inputJar.getEntry("filtered-out.txt") != null
+    assert inputJar.getEntry("dependency/Used.class") == null
+} finally {
+    inputJar.close()
+}

--- a/src/it/projects/MSHADE-154-input-classifier/verify.groovy
+++ b/src/it/projects/MSHADE-154-input-classifier/verify.groovy
@@ -58,4 +58,17 @@ try {
     pomInputJar.close()
 }
 
+["sources", "tests", "test-sources"].each { classifier ->
+    File auxiliaryFile = new File(basedir, "pom-input/target/pom-input-1.0-shaded-${classifier}.jar")
+    assert auxiliaryFile.isFile()
+    assert !new File(basedir, "pom-input/target/pom-input-1.0-shaded-${classifier}.pom").exists()
+
+    JarFile auxiliaryJar = new JarFile(auxiliaryFile)
+    try {
+        assert auxiliaryJar.getEntry("example.txt") != null
+    } finally {
+        auxiliaryJar.close()
+    }
+}
+
 assert new File(basedir, "pom-input/pom.xml").text.startsWith("<?xml")

--- a/src/it/projects/MSHADE-154-input-classifier/verify.groovy
+++ b/src/it/projects/MSHADE-154-input-classifier/verify.groovy
@@ -72,3 +72,28 @@ try {
 }
 
 assert new File(basedir, "pom-input/pom.xml").text.startsWith("<?xml")
+
+File zipInputFile = new File(basedir, "zip-input/target/zip-input-1.0-shaded.zip")
+assert zipInputFile.isFile()
+
+JarFile zipInput = new JarFile(zipInputFile)
+try {
+    assert zipInput.getEntry("example.txt") != null
+} finally {
+    zipInput.close()
+}
+
+["sources", "tests", "test-sources"].each { classifier ->
+    File auxiliaryFile = new File(basedir, "zip-input/target/zip-input-1.0-shaded-${classifier}.jar")
+    assert auxiliaryFile.isFile()
+    assert !new File(basedir, "zip-input/target/zip-input-1.0-shaded-${classifier}.zip").exists()
+
+    JarFile auxiliaryJar = new JarFile(auxiliaryFile)
+    try {
+        assert auxiliaryJar.getEntry("example.txt") != null
+    } finally {
+        auxiliaryJar.close()
+    }
+}
+
+assert new File(basedir, "zip-input/pom.xml").text.startsWith("<?xml")

--- a/src/it/projects/MSHADE-154-input-classifier/zip-input/payload/example.txt
+++ b/src/it/projects/MSHADE-154-input-classifier/zip-input/payload/example.txt
@@ -1,0 +1,18 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+attached ZIP input

--- a/src/it/projects/MSHADE-154-input-classifier/zip-input/pom.xml
+++ b/src/it/projects/MSHADE-154-input-classifier/zip-input/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.shade.mshade154</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>zip-input</artifactId>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>@version.maven-assembly-plugin@</version>
+        <executions>
+          <execution>
+            <id>attach-input</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/assembly/thin.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>sources</classifier>
+              <classesDirectory>${project.basedir}/payload</classesDirectory>
+              <skipIfEmpty>false</skipIfEmpty>
+            </configuration>
+          </execution>
+          <execution>
+            <id>attach-tests</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>tests</classifier>
+              <classesDirectory>${project.basedir}/payload</classesDirectory>
+              <skipIfEmpty>false</skipIfEmpty>
+            </configuration>
+          </execution>
+          <execution>
+            <id>attach-test-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>test-sources</classifier>
+              <classesDirectory>${project.basedir}/payload</classesDirectory>
+              <skipIfEmpty>false</skipIfEmpty>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <inputClassifier>thin</inputClassifier>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <createSourcesJar>true</createSourcesJar>
+              <shadeTestJar>true</shadeTestJar>
+              <createTestSourcesJar>true</createTestSourcesJar>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MSHADE-154-input-classifier/zip-input/src/assembly/thin.xml
+++ b/src/it/projects/MSHADE-154-input-classifier/zip-input/src/assembly/thin.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>thin</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/payload</directory>
+      <outputDirectory>/</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
+++ b/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
@@ -95,15 +95,34 @@ public class MinijarFilter implements Filter {
      */
     public MinijarFilter(MavenProject project, Log log, List<SimpleFilter> simpleFilters, Set<String> entryPoints)
             throws IOException {
+        this(project, project.getArtifact(), log, simpleFilters, entryPoints);
+    }
+
+    /**
+     * @param project {@link MavenProject}
+     * @param artifact primary artifact to analyze
+     * @param log {@link Log}
+     * @param simpleFilters {@link SimpleFilter}
+     * @param entryPoints
+     * @throws IOException in case of errors.
+     * @since 3.6.3
+     */
+    public MinijarFilter(
+            MavenProject project,
+            Artifact artifact,
+            Log log,
+            List<SimpleFilter> simpleFilters,
+            Set<String> entryPoints)
+            throws IOException {
         this.log = log;
 
-        File artifactFile = project.getArtifact().getFile();
+        File artifactFile = artifact.getFile();
 
         if (artifactFile != null) {
             Clazzpath cp = new Clazzpath();
 
-            ClazzpathUnit artifactUnit =
-                    cp.addClazzpathUnit(Files.newInputStream(artifactFile.toPath()), project.toString());
+            ClazzpathUnit artifactUnit = cp.addClazzpathUnit(
+                    Files.newInputStream(artifactFile.toPath()), artifact.toString());
 
             for (Artifact dependency : project.getArtifacts()) {
                 addDependencyToClasspath(cp, dependency);

--- a/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
+++ b/src/main/java/org/apache/maven/plugins/shade/filter/MinijarFilter.java
@@ -108,11 +108,7 @@ public class MinijarFilter implements Filter {
      * @since 3.6.3
      */
     public MinijarFilter(
-            MavenProject project,
-            Artifact artifact,
-            Log log,
-            List<SimpleFilter> simpleFilters,
-            Set<String> entryPoints)
+            MavenProject project, Artifact artifact, Log log, List<SimpleFilter> simpleFilters, Set<String> entryPoints)
             throws IOException {
         this.log = log;
 
@@ -121,8 +117,8 @@ public class MinijarFilter implements Filter {
         if (artifactFile != null) {
             Clazzpath cp = new Clazzpath();
 
-            ClazzpathUnit artifactUnit = cp.addClazzpathUnit(
-                    Files.newInputStream(artifactFile.toPath()), artifact.toString());
+            ClazzpathUnit artifactUnit =
+                    cp.addClazzpathUnit(Files.newInputStream(artifactFile.toPath()), artifact.toString());
 
             for (Artifact dependency : project.getArtifacts()) {
                 addDependencyToClasspath(cp, dependency);

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -493,13 +493,15 @@ public class ShadeMojo extends AbstractMojo {
         Set<File> testSourceArtifacts = new LinkedHashSet<>();
 
         Artifact inputArtifact = selectInputArtifact();
+        validateInputArtifactOutput(inputArtifact);
         ArtifactSelector artifactSelector = new ArtifactSelector(inputArtifact, artifactSet, shadedGroupFilter);
 
         if (artifactSelector.isSelected(inputArtifact) && !"pom".equals(inputArtifact.getType())) {
             if (invalidArtifact(inputArtifact)) {
                 if (isInputClassifierSet()) {
-                    throw new MojoExecutionException("Failed to create shaded artifact, attached artifact with classifier '"
-                            + inputClassifier.trim() + "' does not exist.");
+                    throw new MojoExecutionException(
+                            "Failed to create shaded artifact, attached artifact with classifier '"
+                                    + inputClassifier.trim() + "' does not exist.");
                 } else {
                     createErrorOutput();
                     throw new MojoExecutionException(
@@ -545,7 +547,7 @@ public class ShadeMojo extends AbstractMojo {
         List<Artifact> processedArtifacts = processArtifactSelectors(
                 artifacts, artifactIds, sourceArtifacts, testArtifacts, testSourceArtifacts, artifactSelector);
 
-        File outputJar = (outputFile != null) ? outputFile : shadedArtifactFileWithClassifier();
+        File outputJar = (outputFile != null) ? outputFile : shadedArtifactFileWithClassifier(inputArtifact);
         File sourcesJar = shadedSourceArtifactFileWithClassifier();
         File testJar = shadedTestArtifactFileWithClassifier();
         File testSourcesJar = shadedTestSourceArtifactFileWithClassifier();
@@ -605,11 +607,9 @@ public class ShadeMojo extends AbstractMojo {
                 // rename the output file if a specific finalName is set
                 // but don't rename if the finalName is the <build><finalName>
                 // because this will be handled implicitly later
-                if (finalName != null
-                        && finalName.length() > 0 //
-                        && !finalName.equals(project.getBuild().getFinalName())) {
-                    String finalFileName = finalName + "."
-                            + project.getArtifact().getArtifactHandler().getExtension();
+                if (hasCustomFinalName()) {
+                    String finalFileName =
+                            finalName + "." + inputArtifact.getArtifactHandler().getExtension();
                     File finalFile = new File(outputDirectory, finalFileName);
                     replaceFile(finalFile, outputJar);
                     outputJar = finalFile;
@@ -642,8 +642,7 @@ public class ShadeMojo extends AbstractMojo {
 
                 if (shadedArtifactAttached) {
                     getLog().info("Attaching shaded artifact.");
-                    projectHelper.attachArtifact(
-                            project, project.getArtifact().getType(), shadedClassifierName, outputJar);
+                    projectHelper.attachArtifact(project, inputArtifact.getType(), shadedClassifierName, outputJar);
                     if (createSourcesJar) {
                         projectHelper.attachArtifact(
                                 project, "java-source", shadedClassifierName + "-sources", sourcesJar);
@@ -685,8 +684,7 @@ public class ShadeMojo extends AbstractMojo {
                     }
 
                     if (createTestSourcesJar) {
-                        getLog().info("Replacing original test source artifact "
-                                + "with shaded test source artifact.");
+                        getLog().info("Replacing original test source artifact " + "with shaded test source artifact.");
                         File shadedTestSources = shadedTestSourcesArtifactFile();
 
                         replaceFile(shadedTestSources, testSourcesJar);
@@ -739,6 +737,27 @@ public class ShadeMojo extends AbstractMojo {
 
     private boolean isInputClassifierSet() {
         return inputClassifier != null && !inputClassifier.trim().isEmpty();
+    }
+
+    void validateInputArtifactOutput(Artifact inputArtifact) throws MojoExecutionException {
+        if (outputFile != null || shadedArtifactAttached || hasCustomFinalName()) {
+            return;
+        }
+
+        Artifact mainArtifact = project.getArtifact();
+        String mainExtension = mainArtifact.getArtifactHandler().getExtension();
+        String inputExtension = inputArtifact.getArtifactHandler().getExtension();
+        if (!mainExtension.equals(inputExtension)) {
+            throw new MojoExecutionException("Cannot replace the project main artifact of type '"
+                    + mainArtifact.getType() + "' with the selected attached artifact of type '"
+                    + inputArtifact.getType() + "'. Configure shadedArtifactAttached=true or outputFile instead.");
+        }
+    }
+
+    private boolean hasCustomFinalName() {
+        return finalName != null
+                && !finalName.isEmpty()
+                && !finalName.equals(project.getBuild().getFinalName());
     }
 
     private ShadeRequest shadeRequest(
@@ -1089,8 +1108,7 @@ public class ShadeMojo extends AbstractMojo {
             if (entryPoints == null) {
                 entryPoints = new HashSet<>();
             }
-            getLog().info("Minimizing jar " + inputArtifact
-                    + (entryPoints.isEmpty() ? "" : " with entry points"));
+            getLog().info("Minimizing jar " + inputArtifact + (entryPoints.isEmpty() ? "" : " with entry points"));
 
             try {
                 filters.add(new MinijarFilter(project, inputArtifact, getLog(), simpleFilters, entryPoints));
@@ -1102,8 +1120,7 @@ public class ShadeMojo extends AbstractMojo {
         return filters;
     }
 
-    private File shadedArtifactFileWithClassifier() {
-        Artifact artifact = project.getArtifact();
+    private File shadedArtifactFileWithClassifier(Artifact artifact) {
         final String shadedName = shadedArtifactId + "-" + artifact.getVersion() + "-" + shadedClassifierName + "."
                 + artifact.getArtifactHandler().getExtension();
         return new File(outputDirectory, shadedName);
@@ -1115,7 +1132,8 @@ public class ShadeMojo extends AbstractMojo {
         if (name == null || name.isEmpty()) {
             name = artifact.getArtifactId() + "-" + artifact.getVersion();
         }
-        return new File(outputDirectory, name + "." + artifact.getArtifactHandler().getExtension());
+        return new File(
+                outputDirectory, name + "." + artifact.getArtifactHandler().getExtension());
     }
 
     private File shadedSourceArtifactFileWithClassifier() {

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -237,6 +237,16 @@ public class ShadeMojo extends AbstractMojo {
     private String shadedGroupFilter;
 
     /**
+     * The classifier of an attached artifact to use as the primary input for shading. When this parameter is omitted
+     * or blank, the project's main artifact is used. This parameter does not control the classifier of the shaded
+     * output; see {@link #shadedArtifactAttached} and {@link #shadedClassifierName} for that.
+     *
+     * @since 3.6.3
+     */
+    @Parameter
+    private String inputClassifier;
+
+    /**
      * Defines whether the shaded artifact should be attached as classifier to the original artifact. If false, the
      * shaded jar will be the main artifact of the project
      */
@@ -482,17 +492,22 @@ public class ShadeMojo extends AbstractMojo {
         Set<File> testArtifacts = new LinkedHashSet<>();
         Set<File> testSourceArtifacts = new LinkedHashSet<>();
 
-        ArtifactSelector artifactSelector = new ArtifactSelector(project.getArtifact(), artifactSet, shadedGroupFilter);
+        Artifact inputArtifact = selectInputArtifact();
+        ArtifactSelector artifactSelector = new ArtifactSelector(inputArtifact, artifactSet, shadedGroupFilter);
 
-        if (artifactSelector.isSelected(project.getArtifact())
-                && !"pom".equals(project.getArtifact().getType())) {
-            if (invalidMainArtifact()) {
-                createErrorOutput();
-                throw new MojoExecutionException(
-                        "Failed to create shaded artifact, " + "project main artifact does not exist.");
+        if (artifactSelector.isSelected(inputArtifact) && !"pom".equals(inputArtifact.getType())) {
+            if (invalidArtifact(inputArtifact)) {
+                if (isInputClassifierSet()) {
+                    throw new MojoExecutionException("Failed to create shaded artifact, attached artifact with classifier '"
+                            + inputClassifier.trim() + "' does not exist.");
+                } else {
+                    createErrorOutput();
+                    throw new MojoExecutionException(
+                            "Failed to create shaded artifact, " + "project main artifact does not exist.");
+                }
             }
 
-            artifacts.add(project.getArtifact().getFile());
+            artifacts.add(inputArtifact.getFile());
 
             if (extraJars != null && !extraJars.isEmpty()) {
                 for (File extraJar : extraJars) {
@@ -537,7 +552,7 @@ public class ShadeMojo extends AbstractMojo {
 
         // Now add our extra resources
         try {
-            List<Filter> filters = getFilters(processedArtifacts, artifactSelector);
+            List<Filter> filters = getFilters(inputArtifact, processedArtifacts, artifactSelector);
 
             List<Relocator> relocators = getRelocators();
 
@@ -645,36 +660,38 @@ public class ShadeMojo extends AbstractMojo {
                 } else if (!renamed) {
                     getLog().info("Replacing original artifact with shaded artifact.");
                     File originalArtifact = project.getArtifact().getFile();
-                    if (originalArtifact != null) {
-                        replaceFile(originalArtifact, outputJar);
+                    if (originalArtifact == null || !originalArtifact.isFile()) {
+                        originalArtifact = mainArtifactFile();
+                    }
+                    replaceFile(originalArtifact, outputJar);
+                    project.getArtifact().setFile(originalArtifact);
 
-                        if (createSourcesJar) {
-                            getLog().info("Replacing original source artifact with shaded source artifact.");
-                            File shadedSources = shadedSourcesArtifactFile();
+                    if (createSourcesJar) {
+                        getLog().info("Replacing original source artifact with shaded source artifact.");
+                        File shadedSources = shadedSourcesArtifactFile();
 
-                            replaceFile(shadedSources, sourcesJar);
+                        replaceFile(shadedSources, sourcesJar);
 
-                            projectHelper.attachArtifact(project, "java-source", "sources", shadedSources);
-                        }
+                        projectHelper.attachArtifact(project, "java-source", "sources", shadedSources);
+                    }
 
-                        if (shadeTestJar) {
-                            getLog().info("Replacing original test artifact with shaded test artifact.");
-                            File shadedTests = shadedTestArtifactFile();
+                    if (shadeTestJar) {
+                        getLog().info("Replacing original test artifact with shaded test artifact.");
+                        File shadedTests = shadedTestArtifactFile();
 
-                            replaceFile(shadedTests, testJar);
+                        replaceFile(shadedTests, testJar);
 
-                            projectHelper.attachArtifact(project, "test-jar", shadedTests);
-                        }
+                        projectHelper.attachArtifact(project, "test-jar", shadedTests);
+                    }
 
-                        if (createTestSourcesJar) {
-                            getLog().info("Replacing original test source artifact "
-                                    + "with shaded test source artifact.");
-                            File shadedTestSources = shadedTestSourcesArtifactFile();
+                    if (createTestSourcesJar) {
+                        getLog().info("Replacing original test source artifact "
+                                + "with shaded test source artifact.");
+                        File shadedTestSources = shadedTestSourcesArtifactFile();
 
-                            replaceFile(shadedTestSources, testSourcesJar);
+                        replaceFile(shadedTestSources, testSourcesJar);
 
-                            projectHelper.attachArtifact(project, "java-source", "test-sources", shadedTestSources);
-                        }
+                        projectHelper.attachArtifact(project, "java-source", "test-sources", shadedTestSources);
                     }
                 }
             }
@@ -693,6 +710,35 @@ public class ShadeMojo extends AbstractMojo {
         getLog().error("  remove this binding from your POM such that the goal will be run in");
         getLog().error("  the proper phase.");
         getLog().error("- You removed the configuration of the maven-jar-plugin that produces the main artifact.");
+    }
+
+    Artifact selectInputArtifact() throws MojoExecutionException {
+        if (!isInputClassifierSet()) {
+            return project.getArtifact();
+        }
+
+        String classifier = inputClassifier.trim();
+        List<Artifact> matches = project.getAttachedArtifacts().stream()
+                .filter(artifact -> classifier.equals(artifact.getClassifier()))
+                .collect(Collectors.toList());
+
+        if (matches.isEmpty()) {
+            throw new MojoExecutionException("No attached artifact with classifier '" + classifier
+                    + "' was found. Ensure that the plugin producing the artifact runs before the Shade Plugin.");
+        }
+        if (matches.size() > 1) {
+            String artifacts = matches.stream().map(Artifact::getId).collect(Collectors.joining(", "));
+            throw new MojoExecutionException(
+                    "Multiple attached artifacts with classifier '" + classifier + "' were found: " + artifacts);
+        }
+
+        Artifact artifact = matches.get(0);
+        getLog().info("Using attached artifact " + artifact + " as the primary shade input.");
+        return artifact;
+    }
+
+    private boolean isInputClassifierSet() {
+        return inputClassifier != null && !inputClassifier.trim().isEmpty();
     }
 
     private ShadeRequest shadeRequest(
@@ -862,9 +908,8 @@ public class ShadeMojo extends AbstractMojo {
         return processedArtifacts;
     }
 
-    private boolean invalidMainArtifact() {
-        return project.getArtifact().getFile() == null
-                || !project.getArtifact().getFile().isFile();
+    private boolean invalidArtifact(Artifact artifact) {
+        return artifact.getFile() == null || !artifact.getFile().isFile();
     }
 
     private void replaceFile(File oldFile, File newFile) throws MojoExecutionException {
@@ -975,7 +1020,8 @@ public class ShadeMojo extends AbstractMojo {
         return Arrays.asList(transformers);
     }
 
-    private List<Filter> getFilters(List<Artifact> artifactCollection, ArtifactSelector artifactSelector)
+    private List<Filter> getFilters(
+            Artifact inputArtifact, List<Artifact> artifactCollection, ArtifactSelector artifactSelector)
             throws MojoExecutionException {
         List<Filter> filters = new ArrayList<>();
         List<SimpleFilter> simpleFilters = new ArrayList<>();
@@ -983,8 +1029,8 @@ public class ShadeMojo extends AbstractMojo {
         if (this.filters != null && this.filters.length > 0) {
             Map<Artifact, ArtifactId> artifacts = new HashMap<>();
 
-            // artifactCollection does not contain project; that must also be subjected to filtering
-            artifacts.put(project.getArtifact(), new ArtifactId(project.getArtifact()));
+            // artifactCollection does not contain the primary input; that must also be subjected to filtering
+            artifacts.put(inputArtifact, new ArtifactId(inputArtifact));
 
             for (Artifact artifact : artifactCollection) {
                 if (artifactSelector.isSelected(artifact)) {
@@ -1043,11 +1089,11 @@ public class ShadeMojo extends AbstractMojo {
             if (entryPoints == null) {
                 entryPoints = new HashSet<>();
             }
-            getLog().info("Minimizing jar " + project.getArtifact()
+            getLog().info("Minimizing jar " + inputArtifact
                     + (entryPoints.isEmpty() ? "" : " with entry points"));
 
             try {
-                filters.add(new MinijarFilter(project, getLog(), simpleFilters, entryPoints));
+                filters.add(new MinijarFilter(project, inputArtifact, getLog(), simpleFilters, entryPoints));
             } catch (IOException e) {
                 throw new MojoExecutionException("Failed to analyze class dependencies", e);
             }
@@ -1061,6 +1107,15 @@ public class ShadeMojo extends AbstractMojo {
         final String shadedName = shadedArtifactId + "-" + artifact.getVersion() + "-" + shadedClassifierName + "."
                 + artifact.getArtifactHandler().getExtension();
         return new File(outputDirectory, shadedName);
+    }
+
+    private File mainArtifactFile() {
+        Artifact artifact = project.getArtifact();
+        String name = project.getBuild().getFinalName();
+        if (name == null || name.isEmpty()) {
+            name = artifact.getArtifactId() + "-" + artifact.getVersion();
+        }
+        return new File(outputDirectory, name + "." + artifact.getArtifactHandler().getExtension());
     }
 
     private File shadedSourceArtifactFileWithClassifier() {

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
@@ -456,6 +457,9 @@ public class ShadeMojo extends AbstractMojo {
     private MavenProjectHelper projectHelper;
 
     @Inject
+    private ArtifactHandlerManager artifactHandlerManager;
+
+    @Inject
     private Shader shader;
 
     @Inject
@@ -523,21 +527,21 @@ public class ShadeMojo extends AbstractMojo {
             }
 
             if (createSourcesJar) {
-                File file = shadedSourcesArtifactFile(inputArtifact);
+                File file = shadedSourcesArtifactFile();
                 if (file.isFile()) {
                     sourceArtifacts.add(file);
                 }
             }
 
             if (shadeTestJar) {
-                File file = shadedTestArtifactFile(inputArtifact);
+                File file = shadedTestArtifactFile();
                 if (file.isFile()) {
                     testArtifacts.add(file);
                 }
             }
 
             if (createTestSourcesJar) {
-                File file = shadedTestSourcesArtifactFile(inputArtifact);
+                File file = shadedTestSourcesArtifactFile();
                 if (file.isFile()) {
                     testSourceArtifacts.add(file);
                 }
@@ -548,9 +552,9 @@ public class ShadeMojo extends AbstractMojo {
                 artifacts, artifactIds, sourceArtifacts, testArtifacts, testSourceArtifacts, artifactSelector);
 
         File outputJar = (outputFile != null) ? outputFile : shadedArtifactFileWithClassifier(inputArtifact);
-        File sourcesJar = shadedSourceArtifactFileWithClassifier(inputArtifact);
-        File testJar = shadedTestArtifactFileWithClassifier(inputArtifact);
-        File testSourcesJar = shadedTestSourceArtifactFileWithClassifier(inputArtifact);
+        File sourcesJar = shadedSourceArtifactFileWithClassifier();
+        File testJar = shadedTestArtifactFileWithClassifier();
+        File testSourcesJar = shadedTestSourceArtifactFileWithClassifier();
 
         // Now add our extra resources
         try {
@@ -616,8 +620,7 @@ public class ShadeMojo extends AbstractMojo {
 
                     // Also support the sources JAR
                     if (createSourcesJar) {
-                        finalFileName = finalName + "-sources."
-                                + inputArtifact.getArtifactHandler().getExtension();
+                        finalFileName = finalName + "-sources." + artifactExtension("java-source");
                         finalFile = new File(outputDirectory, finalFileName);
                         replaceFile(finalFile, sourcesJar);
                         sourcesJar = finalFile;
@@ -625,16 +628,14 @@ public class ShadeMojo extends AbstractMojo {
 
                     // Also support the test JAR
                     if (shadeTestJar) {
-                        finalFileName = finalName + "-tests."
-                                + inputArtifact.getArtifactHandler().getExtension();
+                        finalFileName = finalName + "-tests." + artifactExtension("test-jar");
                         finalFile = new File(outputDirectory, finalFileName);
                         replaceFile(finalFile, testJar);
                         testJar = finalFile;
                     }
 
                     if (createTestSourcesJar) {
-                        finalFileName = finalName + "-test-sources."
-                                + inputArtifact.getArtifactHandler().getExtension();
+                        finalFileName = finalName + "-test-sources." + artifactExtension("java-source");
                         finalFile = new File(outputDirectory, finalFileName);
                         replaceFile(finalFile, testSourcesJar);
                         testSourcesJar = finalFile;
@@ -670,7 +671,7 @@ public class ShadeMojo extends AbstractMojo {
 
                     if (createSourcesJar) {
                         getLog().info("Replacing original source artifact with shaded source artifact.");
-                        File shadedSources = shadedSourcesArtifactFile(inputArtifact);
+                        File shadedSources = shadedSourcesArtifactFile();
 
                         replaceFile(shadedSources, sourcesJar);
 
@@ -679,7 +680,7 @@ public class ShadeMojo extends AbstractMojo {
 
                     if (shadeTestJar) {
                         getLog().info("Replacing original test artifact with shaded test artifact.");
-                        File shadedTests = shadedTestArtifactFile(inputArtifact);
+                        File shadedTests = shadedTestArtifactFile();
 
                         replaceFile(shadedTests, testJar);
 
@@ -688,7 +689,7 @@ public class ShadeMojo extends AbstractMojo {
 
                     if (createTestSourcesJar) {
                         getLog().info("Replacing original test source artifact " + "with shaded test source artifact.");
-                        File shadedTestSources = shadedTestSourcesArtifactFile(inputArtifact);
+                        File shadedTestSources = shadedTestSourcesArtifactFile();
 
                         replaceFile(shadedTestSources, testSourcesJar);
 
@@ -1139,48 +1140,53 @@ public class ShadeMojo extends AbstractMojo {
                 outputDirectory, name + "." + artifact.getArtifactHandler().getExtension());
     }
 
-    private File shadedSourceArtifactFileWithClassifier(Artifact artifact) {
-        return shadedArtifactFileWithClassifier(artifact, "sources");
+    private File shadedSourceArtifactFileWithClassifier() {
+        return shadedArtifactFileWithClassifier("java-source", "sources");
     }
 
-    private File shadedTestSourceArtifactFileWithClassifier(Artifact artifact) {
-        return shadedArtifactFileWithClassifier(artifact, "test-sources");
+    private File shadedTestSourceArtifactFileWithClassifier() {
+        return shadedArtifactFileWithClassifier("java-source", "test-sources");
     }
 
-    private File shadedArtifactFileWithClassifier(Artifact artifact, String classifier) {
+    private File shadedArtifactFileWithClassifier(String type, String classifier) {
+        Artifact artifact = project.getArtifact();
         final String shadedName = shadedArtifactId + "-" + artifact.getVersion() + "-" + shadedClassifierName + "-"
-                + classifier + "." + artifact.getArtifactHandler().getExtension();
+                + classifier + "." + artifactExtension(type);
         return new File(outputDirectory, shadedName);
     }
 
-    private File shadedTestArtifactFileWithClassifier(Artifact artifact) {
-        return shadedArtifactFileWithClassifier(artifact, "tests");
+    private File shadedTestArtifactFileWithClassifier() {
+        return shadedArtifactFileWithClassifier("test-jar", "tests");
     }
 
-    private File shadedSourcesArtifactFile(Artifact artifact) {
-        return shadedArtifactFile(artifact, "sources");
+    private File shadedSourcesArtifactFile() {
+        return shadedArtifactFile("java-source", "sources");
     }
 
-    private File shadedTestSourcesArtifactFile(Artifact artifact) {
-        return shadedArtifactFile(artifact, "test-sources");
+    private File shadedTestSourcesArtifactFile() {
+        return shadedArtifactFile("java-source", "test-sources");
     }
 
-    private File shadedArtifactFile(Artifact artifact, String classifier) {
+    private File shadedArtifactFile(String type, String classifier) {
+        Artifact artifact = project.getArtifact();
         String shadedName;
 
         if (project.getBuild().getFinalName() != null) {
-            shadedName = project.getBuild().getFinalName() + "-" + classifier + "."
-                    + artifact.getArtifactHandler().getExtension();
+            shadedName = project.getBuild().getFinalName() + "-" + classifier + "." + artifactExtension(type);
         } else {
-            shadedName = shadedArtifactId + "-" + artifact.getVersion() + "-" + classifier + "."
-                    + artifact.getArtifactHandler().getExtension();
+            shadedName =
+                    shadedArtifactId + "-" + artifact.getVersion() + "-" + classifier + "." + artifactExtension(type);
         }
 
         return new File(outputDirectory, shadedName);
     }
 
-    private File shadedTestArtifactFile(Artifact artifact) {
-        return shadedArtifactFile(artifact, "tests");
+    private File shadedTestArtifactFile() {
+        return shadedArtifactFile("test-jar", "tests");
+    }
+
+    private String artifactExtension(String type) {
+        return artifactHandlerManager.getArtifactHandler(type).getExtension();
     }
 
     // We need to find the direct dependencies that have been included in the uber JAR so that we can modify the

--- a/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/shade/mojo/ShadeMojo.java
@@ -523,21 +523,21 @@ public class ShadeMojo extends AbstractMojo {
             }
 
             if (createSourcesJar) {
-                File file = shadedSourcesArtifactFile();
+                File file = shadedSourcesArtifactFile(inputArtifact);
                 if (file.isFile()) {
                     sourceArtifacts.add(file);
                 }
             }
 
             if (shadeTestJar) {
-                File file = shadedTestArtifactFile();
+                File file = shadedTestArtifactFile(inputArtifact);
                 if (file.isFile()) {
                     testArtifacts.add(file);
                 }
             }
 
             if (createTestSourcesJar) {
-                File file = shadedTestSourcesArtifactFile();
+                File file = shadedTestSourcesArtifactFile(inputArtifact);
                 if (file.isFile()) {
                     testSourceArtifacts.add(file);
                 }
@@ -548,9 +548,9 @@ public class ShadeMojo extends AbstractMojo {
                 artifacts, artifactIds, sourceArtifacts, testArtifacts, testSourceArtifacts, artifactSelector);
 
         File outputJar = (outputFile != null) ? outputFile : shadedArtifactFileWithClassifier(inputArtifact);
-        File sourcesJar = shadedSourceArtifactFileWithClassifier();
-        File testJar = shadedTestArtifactFileWithClassifier();
-        File testSourcesJar = shadedTestSourceArtifactFileWithClassifier();
+        File sourcesJar = shadedSourceArtifactFileWithClassifier(inputArtifact);
+        File testJar = shadedTestArtifactFileWithClassifier(inputArtifact);
+        File testSourcesJar = shadedTestSourceArtifactFileWithClassifier(inputArtifact);
 
         // Now add our extra resources
         try {
@@ -616,7 +616,8 @@ public class ShadeMojo extends AbstractMojo {
 
                     // Also support the sources JAR
                     if (createSourcesJar) {
-                        finalFileName = finalName + "-sources.jar";
+                        finalFileName = finalName + "-sources."
+                                + inputArtifact.getArtifactHandler().getExtension();
                         finalFile = new File(outputDirectory, finalFileName);
                         replaceFile(finalFile, sourcesJar);
                         sourcesJar = finalFile;
@@ -624,14 +625,16 @@ public class ShadeMojo extends AbstractMojo {
 
                     // Also support the test JAR
                     if (shadeTestJar) {
-                        finalFileName = finalName + "-tests.jar";
+                        finalFileName = finalName + "-tests."
+                                + inputArtifact.getArtifactHandler().getExtension();
                         finalFile = new File(outputDirectory, finalFileName);
                         replaceFile(finalFile, testJar);
                         testJar = finalFile;
                     }
 
                     if (createTestSourcesJar) {
-                        finalFileName = finalName + "-test-sources.jar";
+                        finalFileName = finalName + "-test-sources."
+                                + inputArtifact.getArtifactHandler().getExtension();
                         finalFile = new File(outputDirectory, finalFileName);
                         replaceFile(finalFile, testSourcesJar);
                         testSourcesJar = finalFile;
@@ -667,7 +670,7 @@ public class ShadeMojo extends AbstractMojo {
 
                     if (createSourcesJar) {
                         getLog().info("Replacing original source artifact with shaded source artifact.");
-                        File shadedSources = shadedSourcesArtifactFile();
+                        File shadedSources = shadedSourcesArtifactFile(inputArtifact);
 
                         replaceFile(shadedSources, sourcesJar);
 
@@ -676,7 +679,7 @@ public class ShadeMojo extends AbstractMojo {
 
                     if (shadeTestJar) {
                         getLog().info("Replacing original test artifact with shaded test artifact.");
-                        File shadedTests = shadedTestArtifactFile();
+                        File shadedTests = shadedTestArtifactFile(inputArtifact);
 
                         replaceFile(shadedTests, testJar);
 
@@ -685,7 +688,7 @@ public class ShadeMojo extends AbstractMojo {
 
                     if (createTestSourcesJar) {
                         getLog().info("Replacing original test source artifact " + "with shaded test source artifact.");
-                        File shadedTestSources = shadedTestSourcesArtifactFile();
+                        File shadedTestSources = shadedTestSourcesArtifactFile(inputArtifact);
 
                         replaceFile(shadedTestSources, testSourcesJar);
 
@@ -1136,36 +1139,33 @@ public class ShadeMojo extends AbstractMojo {
                 outputDirectory, name + "." + artifact.getArtifactHandler().getExtension());
     }
 
-    private File shadedSourceArtifactFileWithClassifier() {
-        return shadedArtifactFileWithClassifier("sources");
+    private File shadedSourceArtifactFileWithClassifier(Artifact artifact) {
+        return shadedArtifactFileWithClassifier(artifact, "sources");
     }
 
-    private File shadedTestSourceArtifactFileWithClassifier() {
-        return shadedArtifactFileWithClassifier("test-sources");
+    private File shadedTestSourceArtifactFileWithClassifier(Artifact artifact) {
+        return shadedArtifactFileWithClassifier(artifact, "test-sources");
     }
 
-    private File shadedArtifactFileWithClassifier(String classifier) {
-        Artifact artifact = project.getArtifact();
+    private File shadedArtifactFileWithClassifier(Artifact artifact, String classifier) {
         final String shadedName = shadedArtifactId + "-" + artifact.getVersion() + "-" + shadedClassifierName + "-"
                 + classifier + "." + artifact.getArtifactHandler().getExtension();
         return new File(outputDirectory, shadedName);
     }
 
-    private File shadedTestArtifactFileWithClassifier() {
-        return shadedArtifactFileWithClassifier("tests");
+    private File shadedTestArtifactFileWithClassifier(Artifact artifact) {
+        return shadedArtifactFileWithClassifier(artifact, "tests");
     }
 
-    private File shadedSourcesArtifactFile() {
-        return shadedArtifactFile("sources");
+    private File shadedSourcesArtifactFile(Artifact artifact) {
+        return shadedArtifactFile(artifact, "sources");
     }
 
-    private File shadedTestSourcesArtifactFile() {
-        return shadedArtifactFile("test-sources");
+    private File shadedTestSourcesArtifactFile(Artifact artifact) {
+        return shadedArtifactFile(artifact, "test-sources");
     }
 
-    private File shadedArtifactFile(String classifier) {
-        Artifact artifact = project.getArtifact();
-
+    private File shadedArtifactFile(Artifact artifact, String classifier) {
         String shadedName;
 
         if (project.getBuild().getFinalName() != null) {
@@ -1179,8 +1179,8 @@ public class ShadeMojo extends AbstractMojo {
         return new File(outputDirectory, shadedName);
     }
 
-    private File shadedTestArtifactFile() {
-        return shadedArtifactFile("tests");
+    private File shadedTestArtifactFile(Artifact artifact) {
+        return shadedArtifactFile(artifact, "tests");
     }
 
     // We need to find the direct dependencies that have been included in the uber JAR so that we can modify the

--- a/src/test/java/org/apache/maven/plugins/shade/mojo/ShadeMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/mojo/ShadeMojoTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
@@ -289,8 +290,52 @@ public class ShadeMojoTest extends AbstractMojoTestCase {
         }
     }
 
+    public void testRejectIncompatibleInputArtifactReplacement() throws Exception {
+        TestMavenProject project = new TestMavenProject();
+        project.setArtifact(newArtifact(null, "pom"));
+        Artifact inputArtifact = newArtifact("thin", "jar");
+
+        ShadeMojo mojo = new ShadeMojo();
+        setVariableValueToObject(mojo, "project", project);
+
+        try {
+            mojo.validateInputArtifactOutput(inputArtifact);
+            fail("Expected incompatible input artifact replacement to fail");
+        } catch (MojoExecutionException e) {
+            assertTrue(e.getMessage().contains("main artifact of type 'pom'"));
+            assertTrue(e.getMessage().contains("attached artifact of type 'jar'"));
+            assertTrue(e.getMessage().contains("shadedArtifactAttached=true"));
+        }
+    }
+
+    public void testAllowIncompatibleInputArtifactAsAttachment() throws Exception {
+        TestMavenProject project = new TestMavenProject();
+        project.setArtifact(newArtifact(null, "pom"));
+
+        ShadeMojo mojo = new ShadeMojo();
+        setVariableValueToObject(mojo, "project", project);
+        setVariableValueToObject(mojo, "shadedArtifactAttached", true);
+
+        mojo.validateInputArtifactOutput(newArtifact("thin", "jar"));
+    }
+
+    public void testAllowCompatibleInputArtifactExtension() throws Exception {
+        TestMavenProject project = new TestMavenProject();
+        project.setArtifact(newArtifact(null, "maven-plugin", "jar"));
+
+        ShadeMojo mojo = new ShadeMojo();
+        setVariableValueToObject(mojo, "project", project);
+
+        mojo.validateInputArtifactOutput(newArtifact("thin", "jar"));
+    }
+
     private Artifact newArtifact(String classifier, String type) throws Exception {
-        ArtifactHandler artifactHandler = lookup(ArtifactHandler.class);
+        return newArtifact(classifier, type, type);
+    }
+
+    private Artifact newArtifact(String classifier, String type, String extension) {
+        DefaultArtifactHandler artifactHandler = new DefaultArtifactHandler(type);
+        artifactHandler.setExtension(extension);
         return new DefaultArtifact(
                 "org.apache.maven.its",
                 "test-project",

--- a/src/test/java/org/apache/maven/plugins/shade/mojo/ShadeMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/shade/mojo/ShadeMojoTest.java
@@ -37,6 +37,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.plugins.shade.ShadeRequest;
 import org.apache.maven.plugins.shade.Shader;
@@ -214,10 +215,11 @@ public class ShadeMojoTest extends AbstractMojoTestCase {
         filtersField.set(mojo, new ArchiveFilter[] {archiveFilter});
 
         // invoke getFilters()
-        Method getFilters = ShadeMojo.class.getDeclaredMethod("getFilters", List.class, ArtifactSelector.class);
+        Method getFilters =
+                ShadeMojo.class.getDeclaredMethod("getFilters", Artifact.class, List.class, ArtifactSelector.class);
         getFilters.setAccessible(true);
         ArtifactSelector selector = new ArtifactSelector(Collections.emptyList(), Collections.emptyList(), null);
-        List<Filter> filters = (List<Filter>) getFilters.invoke(mojo, Collections.emptyList(), selector);
+        List<Filter> filters = (List<Filter>) getFilters.invoke(mojo, artifact, Collections.emptyList(), selector);
 
         // assertions - there must be one filter
         assertEquals(1, filters.size());
@@ -226,6 +228,83 @@ public class ShadeMojoTest extends AbstractMojoTestCase {
         Filter filter = filters.get(0);
         assertTrue(filter.canFilter(new File("myfaces-impl-2.0.1-SNAPSHOT.jar"))); // binary jar
         assertTrue(filter.canFilter(new File("myfaces-impl-2.0.1-SNAPSHOT-sources.jar"))); // sources jar
+    }
+
+    public void testSelectMainArtifactByDefault() throws Exception {
+        TestMavenProject project = new TestMavenProject();
+        Artifact mainArtifact = newArtifact(null, "jar");
+        project.setArtifact(mainArtifact);
+
+        ShadeMojo mojo = new ShadeMojo();
+        setVariableValueToObject(mojo, "project", project);
+        setVariableValueToObject(mojo, "inputClassifier", "  ");
+
+        assertSame(mainArtifact, mojo.selectInputArtifact());
+    }
+
+    public void testSelectAttachedInputArtifact() throws Exception {
+        TestMavenProject project = new TestMavenProject();
+        project.setArtifact(newArtifact(null, "jar"));
+        Artifact attachedArtifact = newArtifact("thin", "jar");
+        project.setTestAttachedArtifacts(attachedArtifact);
+
+        ShadeMojo mojo = new ShadeMojo();
+        mojo.setLog(mock(org.apache.maven.plugin.logging.Log.class));
+        setVariableValueToObject(mojo, "project", project);
+        setVariableValueToObject(mojo, "inputClassifier", "thin");
+
+        assertSame(attachedArtifact, mojo.selectInputArtifact());
+    }
+
+    public void testMissingInputClassifierFails() throws Exception {
+        TestMavenProject project = new TestMavenProject();
+        project.setArtifact(newArtifact(null, "jar"));
+
+        ShadeMojo mojo = new ShadeMojo();
+        setVariableValueToObject(mojo, "project", project);
+        setVariableValueToObject(mojo, "inputClassifier", "thin");
+
+        try {
+            mojo.selectInputArtifact();
+            fail("Expected missing input classifier to fail");
+        } catch (MojoExecutionException e) {
+            assertTrue(e.getMessage().contains("No attached artifact with classifier 'thin' was found"));
+        }
+    }
+
+    public void testAmbiguousInputClassifierFails() throws Exception {
+        TestMavenProject project = new TestMavenProject();
+        project.setArtifact(newArtifact(null, "jar"));
+        project.setTestAttachedArtifacts(newArtifact("thin", "jar"), newArtifact("thin", "zip"));
+
+        ShadeMojo mojo = new ShadeMojo();
+        setVariableValueToObject(mojo, "project", project);
+        setVariableValueToObject(mojo, "inputClassifier", "thin");
+
+        try {
+            mojo.selectInputArtifact();
+            fail("Expected ambiguous input classifier to fail");
+        } catch (MojoExecutionException e) {
+            assertTrue(e.getMessage().contains("Multiple attached artifacts with classifier 'thin' were found"));
+        }
+    }
+
+    private Artifact newArtifact(String classifier, String type) throws Exception {
+        ArtifactHandler artifactHandler = lookup(ArtifactHandler.class);
+        return new DefaultArtifact(
+                "org.apache.maven.its",
+                "test-project",
+                VersionRange.createFromVersion("1.0"),
+                "compile",
+                type,
+                classifier,
+                artifactHandler);
+    }
+
+    private static class TestMavenProject extends MavenProject {
+        void setTestAttachedArtifacts(Artifact... artifacts) {
+            setAttachedArtifacts(Arrays.asList(artifacts));
+        }
     }
 
     public void shaderWithPattern(String shadedPattern, File jar) throws Exception {


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHADE) filed
       for the change (usually before you start working on it). Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request has a meaningful subject line and body.
 - [x] The pull request title uses the corresponding MSHADE issue number.
 - [x] The pull request description explains what the pull request does, how, and why.
 - [x] `mvn clean verify` passes.
 - [x] The integration tests pass with `mvn -Prun-its clean verify`.

## Summary

Add an optional `inputClassifier` parameter that lets the Shade Plugin use an
artifact attached to the current project as its primary input. When the
parameter is omitted or blank, the plugin continues to use the project's main
artifact.

## Root cause

The plugin always used `MavenProject#getArtifact()` as the primary input. A
plugin could produce and attach a classified JAR before the shade execution,
but Shade had no way to select it. Projects that intentionally produced only
the classified artifact consequently failed because the main artifact did not
exist.

## Implementation

The selected attachment is found directly in the current project's attached
artifacts. Missing and ambiguous classifier selections fail with actionable
messages. The selected artifact is then used consistently for artifact-set
selection, archive filtering, and minimization.

When the shaded artifact is not attached separately, it retains the existing
output semantics and becomes the project's main artifact. The original
classified input remains attached and is not overwritten.

The new integration test covers selection of a classified input, archive
filtering, dependency minimization, preservation of the input attachment, and
installation of the shaded JAR as the main artifact. Unit tests cover default,
successful, missing, and ambiguous selection.

## Verification

 - `mvn clean verify` — 76 tests passed
 - `mvn -Prun-its clean verify` — 84 integration tests passed; 2 existing
   JRE-dependent tests were skipped under Java 8
 - The focused reproducer also passed under Maven 4.0.0-rc-5

Fixes #516.

To make clear that I license this contribution under the
[Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0),
I acknowledge this using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
